### PR TITLE
Refactor: Improve DNS constant handling and map generation

### DIFF
--- a/lib/dns.ex
+++ b/lib/dns.ex
@@ -3,228 +3,163 @@ defmodule DNS do
   DNS related constants
   """
 
-  def type() do
-    %{
-      1 => :a,
-      :a => 1,
-      2 => :ns,
-      :ns => 2,
-      3 => :md,
-      :md => 3,
-      4 => :mf,
-      :mf => 4,
-      5 => :cname,
-      :cname => 5,
-      6 => :soa,
-      :soa => 6,
-      7 => :mb,
-      :mb => 7,
-      8 => :mg,
-      :mg => 8,
-      9 => :mr,
-      :mr => 9,
-      10 => :null,
-      :null => 10,
-      11 => :wks,
-      :wks => 11,
-      12 => :ptr,
-      :ptr => 12,
-      13 => :hinfo,
-      :hinfo => 13,
-      14 => :minfo,
-      :minfo => 14,
-      15 => :mx,
-      :mx => 15,
-      16 => :txt,
-      :txt => 16,
-      17 => :rp,
-      :rp => 17,
-      18 => :afsdb,
-      :afsdb => 18,
-      19 => :x25,
-      :x25 => 19,
-      20 => :isdn,
-      :isdn => 20,
-      21 => :rt,
-      :rt => 21,
-      22 => :nsap,
-      :nsap => 22,
-      23 => :nsap_ptr,
-      :nsap_ptr => 23,
-      24 => :sig,
-      :sig => 24,
-      25 => :key,
-      :key => 25,
-      26 => :px,
-      :px => 26,
-      27 => :gpos,
-      :gpos => 27,
-      28 => :aaaa,
-      :aaaa => 28,
-      29 => :loc,
-      :loc => 29,
-      30 => :nxt,
-      :nxt => 30,
-      31 => :eid,
-      :eid => 31,
-      32 => :nimloc,
-      :nimloc => 32,
-      33 => :srv,
-      :srv => 33,
-      34 => :atma,
-      :atma => 34,
-      41 => :opt,
-      :opt => 41,
-      64 => :svcb,
-      :svcb => 64,
-      65 => :https,
-      :https => 65,
-      252 => :axfr,
-      :axfr => 252,
-      255 => :all,
-      :all => 255,
-      :any => 255,
-      257 => :caa,
-      :caa => 257
-    }
-  end
+  # type定義
+  @type_pairs [
+    {1, :a},
+    {2, :ns},
+    {3, :md},
+    {4, :mf},
+    {5, :cname},
+    {6, :soa},
+    {7, :mb},
+    {8, :mg},
+    {9, :mr},
+    {10, :null},
+    {11, :wks},
+    {12, :ptr},
+    {13, :hinfo},
+    {14, :minfo},
+    {15, :mx},
+    {16, :txt},
+    {17, :rp},
+    {18, :afsdb},
+    {19, :x25},
+    {20, :isdn},
+    {21, :rt},
+    {22, :nsap},
+    {23, :nsap_ptr},
+    {24, :sig},
+    {25, :key},
+    {26, :px},
+    {27, :gpos},
+    {28, :aaaa},
+    {29, :loc},
+    {30, :nxt},
+    {31, :eid},
+    {32, :nimloc},
+    {33, :srv},
+    {34, :atma},
+    {41, :opt},
+    {64, :svcb},
+    {65, :https},
+    {252, :axfr},
+    {255, :all},
+    {255, :any},
+    {257, :caa}
+  ]
 
-  def class() do
-    %{
-      1 => :in,
-      :in => 1,
-      2 => :cs,
-      :cs => 2,
-      3 => :ch,
-      :ch => 3,
-      4 => :hs,
-      :hs => 4,
-      254 => :none,
-      :none => 254,
-      255 => :any,
-      :any => 255,
-      65_536 => :max,
-      :max => 65_536
-    }
-  end
+  # class定義
+  @class_pairs [
+    {1, :in},
+    {2, :cs},
+    {3, :ch},
+    {4, :hs},
+    {254, :none},
+    {255, :any},
+    {65_536, :max}
+  ]
 
-  def rcode() do
-    %{
-      0 => :noerror,
-      :noerror => 0,
-      1 => :formerr,
-      :formerr => 1,
-      2 => :servfail,
-      :servfail => 2,
-      3 => :nxdomain,
-      :nxdomain => 3,
-      4 => :notimp,
-      :notimp => 4,
-      5 => :refused,
-      :refused => 5,
-      6 => :yxdomain,
-      :yxdomain => 6,
-      7 => :yxrrset,
-      :yxrrset => 7,
-      8 => :nxrrset,
-      :nxrrset => 8,
-      9 => :notauth,
-      :notauth => 9,
-      10 => :notzone,
-      :notzone => 10,
-      11 => :dsotypeni,
-      :dsotypeni => 11,
-      16 => :badvers,
-      :badvers => 16,
-      :badsig => 16,
-      17 => :badkey,
-      :badkey => 17,
-      18 => :badtime,
-      :badtime => 18,
-      19 => :badmode,
-      :badmode => 19,
-      20 => :badname,
-      :badname => 20,
-      21 => :badalg,
-      :badalg => 21,
-      22 => :badtrunc,
-      :badtrunc => 22,
-      23 => :badcookie,
-      :badcookie => 23
-    }
-  end
+  # rcode定義
+  @rcode_pairs [
+    {0, :noerror},
+    {1, :formerr},
+    {2, :servfail},
+    {3, :nxdomain},
+    {4, :notimp},
+    {5, :refused},
+    {6, :yxdomain},
+    {7, :yxrrset},
+    {8, :nxrrset},
+    {9, :notauth},
+    {10, :notzone},
+    {11, :dsotypeni},
+    {16, :badvers},
+    {16, :badsig},
+    {17, :badkey},
+    {18, :badtime},
+    {19, :badmode},
+    {20, :badname},
+    {21, :badalg},
+    {22, :badtrunc},
+    {23, :badcookie}
+  ]
 
-  def rcode_text() do
-    %{
-      :noerror => "No Error",
-      :formerr => "Format Error",
-      :servfail => "Server Failure",
-      :nxdomain => "Non-Existent Domain",
-      :notimp => "Not Implemented",
-      :refused => "Query Refused",
-      :yxdomain => "Name Exists when it should not",
-      :yxrrset => "RR Set Exists when it should not",
-      :nxrrset => "RR Set tha should exist does not",
-      :notauth => "Server Not Authoritative for zone",
-      :notzone => "Name not contained in zone",
-      :dsotypeni => "DSO-TYPE Not Implemented",
-      :badvers => "Bad OPT Version / TSIG Signature Failure",
-      :badsig => "Bad OPT Version / TSIG Signature Failure",
-      :badkey => "Key not recognized",
-      :badtime => "Signature out of time window",
-      :badmode => "Bad TKEY Mode",
-      :badname => "Duplicate key name",
-      :badalg => "Algorithm not supported",
-      :badtrunc => "Bad Truncation",
-      :badcookie => "Bad/missing Server Cookie"
-    }
-  end
+  # option定義
+  @option_pairs [
+    {0, :reserved0},
+    {1, :llq},
+    {2, :ul},
+    {3, :nsid},
+    {4, :reserved4},
+    {5, :dau},
+    {6, :dhu},
+    {7, :n3u},
+    {8, :edns_client_subnet},
+    {9, :edns_expire},
+    {10, :cookie},
+    {11, :edns_tcp_keepalive},
+    {12, :padding},
+    {13, :chain},
+    {14, :edns_key_tag},
+    {15, :extended_dns_error},
+    {16, :edns_client_tag},
+    {17, :edns_server_tag},
+    {26_946, :deviceid}
+  ]
 
-  def option() do
-    %{
-      0 => :reserved0,
-      :reserved0 => 0,
-      1 => :llq,
-      :llq => 1,
-      2 => :ul,
-      :ul => 2,
-      3 => :nsid,
-      :nsid => 3,
-      4 => :reserved4,
-      :reserved4 => 4,
-      5 => :dau,
-      :dau => 5,
-      6 => :dhu,
-      :dhu => 6,
-      7 => :n3u,
-      :n3u => 7,
-      8 => :edns_client_subnet,
-      :edns_client_subnet => 8,
-      9 => :edns_expire,
-      :edns_expire => 9,
-      10 => :cookie,
-      :cookie => 10,
-      11 => :edns_tcp_keepalive,
-      :edns_tcp_keepalive => 11,
-      12 => :padding,
-      :padding => 12,
-      13 => :chain,
-      :chain => 13,
-      14 => :edns_key_tag,
-      :edns_key_tag => 14,
-      15 => :extended_dns_error,
-      :extended_dns_error => 15,
-      16 => :edns_client_tag,
-      :edns_client_tag => 16,
-      17 => :edns_server_tag,
-      :edns_server_tag => 17,
-      26_946 => :deviceid,
-      :deviceid => 26_946
-    }
-  end
+  @type_map Map.new(@type_pairs)
+  @type_reverse_map Map.new(@type_pairs, fn {k, v} -> {v, k} end)
 
-  def port(), do: 53
-  def service(), do: "domain"
+  def type(num), do: Map.get(@type_map, num)
+  def type_code(atom), do: Map.get(@type_reverse_map, atom)
+
+  @class_map Map.new(@class_pairs)
+  @class_reverse_map Map.new(@class_pairs, fn {k, v} -> {v, k} end)
+
+  def class(num), do: Map.get(@class_map, num)
+  def class_code(atom), do: Map.get(@class_reverse_map, atom)
+
+  @rcode_map Map.new(@rcode_pairs)
+  @rcode_reverse_map Map.new(@rcode_pairs, fn {k, v} -> {v, k} end)
+
+  def rcode(num), do: Map.get(@rcode_map, num)
+  def rcode_code(atom), do: Map.get(@rcode_reverse_map, atom)
+
+  @option_map Map.new(@option_pairs)
+  @option_reverse_map Map.new(@option_pairs, fn {k, v} -> {v, k} end)
+
+  def option(num), do: Map.get(@option_map, num)
+  def option_code(atom), do: Map.get(@option_reverse_map, atom)
+
+  @default_port 53
+  @default_service "domain"
+
+  def rcode_text(), do: %{
+    :noerror => "No Error",
+    :formerr => "Format Error",
+    :servfail => "Server Failure",
+    :nxdomain => "Non-Existent Domain",
+    :notimp => "Not Implemented",
+    :refused => "Query Refused",
+    :yxdomain => "Name Exists when it should not",
+    :yxrrset => "RR Set Exists when it should not",
+    :nxrrset => "RR Set that should exist does not",
+    :notauth => "Server Not Authoritative for zone",
+    :notzone => "Name not contained in zone",
+    :dsotypeni => "DSO-TYPE Not Implemented",
+    :badvers => "Bad OPT Version / TSIG Signature Failure",
+    :badsig => "Bad OPT Version / TSIG Signature Failure",
+    :badkey => "Key not recognized",
+    :badtime => "Signature out of time window",
+    :badmode => "Bad TKEY Mode",
+    :badname => "Duplicate key name",
+    :badalg => "Algorithm not supported",
+    :badtrunc => "Bad Truncation",
+    :badcookie => "Bad/missing Server Cookie"
+  }
+
+  def port(), do: @default_port
+  def service(), do: @default_service
 
   def edns_max_udpsize(), do: 1232
 end


### PR DESCRIPTION
- Separated maps for numeric codes to atoms and atoms to numeric codes lookups.
- Ensured consistent naming for functions converting between numeric codes and atoms (e.g., `type/1`, `type_code/1`).
- Utilized module attributes for default values like port, service, and EDNS max UDP size, making them compile-time constants.