### PR TITLE
Improve code quality based on Credo analysis

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,136 @@
+%{
+  configs: [
+    %{
+      name: "default",
+      files: %{
+        included: ["lib/", "test/"],
+        excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
+      },
+      requires: [],
+      strict: false,
+      color: true,
+      checks: %{
+        enabled: [
+          #
+          ## Consistency Checks
+          #
+          {Credo.Check.Consistency.ExceptionNames, []},
+          {Credo.Check.Consistency.LineEndings, []},
+          {Credo.Check.Consistency.ParameterPatternMatching, []},
+          {Credo.Check.Consistency.SpaceAroundOperators, []},
+          {Credo.Check.Consistency.SpaceInParentheses, []},
+          {Credo.Check.Consistency.TabsOrSpaces, []},
+
+          #
+          ## Design Checks
+          #
+          {Credo.Check.Design.AliasUsage,
+           [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
+          {Credo.Check.Design.TagTODO, [exit_status: 2]},
+          {Credo.Check.Design.TagFIXME, []},
+
+          #
+          ## Readability Checks
+          #
+          {Credo.Check.Readability.AliasOrder, []},
+          {Credo.Check.Readability.FunctionNames, []},
+          {Credo.Check.Readability.LargeNumbers, []},
+          {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 120]},
+          {Credo.Check.Readability.ModuleAttributeNames, []},
+          {Credo.Check.Readability.ModuleDoc, []},
+          {Credo.Check.Readability.ModuleNames, []},
+          {Credo.Check.Readability.ParenthesesInCondition, []},
+          {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
+          {Credo.Check.Readability.PredicateFunctionNames, []},
+          {Credo.Check.Readability.PreferImplicitTry, []},
+          {Credo.Check.Readability.RedundantBlankLines, []},
+          {Credo.Check.Readability.Semicolons, []},
+          {Credo.Check.Readability.SpaceAfterCommas, []},
+          {Credo.Check.Readability.StringSigils, []},
+          {Credo.Check.Readability.TrailingBlankLine, []},
+          {Credo.Check.Readability.TrailingWhiteSpace, []},
+          {Credo.Check.Readability.UnnecessaryAliasExpansion, []},
+          {Credo.Check.Readability.VariableNames, []},
+
+          #
+          ## Refactoring Opportunities
+          #
+          {Credo.Check.Refactor.CondStatements, []},
+          {Credo.Check.Refactor.CyclomaticComplexity, []},
+          {Credo.Check.Refactor.FunctionArity, []},
+          {Credo.Check.Refactor.LongQuoteBlocks, []},
+          {Credo.Check.Refactor.MatchInCondition, []},
+          {Credo.Check.Refactor.NegatedConditionsInUnless, []},
+          {Credo.Check.Refactor.NegatedConditionsWithElse, []},
+          {Credo.Check.Refactor.Nesting, []},
+          {Credo.Check.Refactor.UnlessWithElse, []},
+          {Credo.Check.Refactor.WithClauses, []},
+
+          #
+          ## Warnings
+          #
+          {Credo.Check.Warning.ApplicationConfigInModuleAttribute, []},
+          {Credo.Check.Warning.BoolOperationOnSameValues, []},
+          {Credo.Check.Warning.ExpensiveEmptyEnumCheck, []},
+          {Credo.Check.Warning.IExPry, []},
+          {Credo.Check.Warning.IoInspect, []},
+          {Credo.Check.Warning.OperationOnSameValues, []},
+          {Credo.Check.Warning.OperationWithConstantResult, []},
+          {Credo.Check.Warning.RaiseInsideRescue, []},
+          {Credo.Check.Warning.UnusedEnumOperation, []},
+          {Credo.Check.Warning.UnusedFileOperation, []},
+          {Credo.Check.Warning.UnusedKeywordOperation, []},
+          {Credo.Check.Warning.UnusedListOperation, []},
+          {Credo.Check.Warning.UnusedPathOperation, []},
+          {Credo.Check.Warning.UnusedRegexOperation, []},
+          {Credo.Check.Warning.UnusedStringOperation, []},
+          {Credo.Check.Warning.UnusedTupleOperation, []},
+          {Credo.Check.Warning.UnsafeExec, []},
+
+          #
+          ## Controversial and experimental checks (opt-in, just move the check to `:enabled`
+          #  and be sure to use `mix credo --strict` to see low priority checks)
+          #
+          {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
+          {Credo.Check.Consistency.UnusedVariableNames, false},
+          {Credo.Check.Design.DuplicatedCode, []},
+          {Credo.Check.Readability.AliasAs, []},
+          {Credo.Check.Readability.BlockPipe, []},
+          {Credo.Check.Readability.ImplTrue, []},
+          {Credo.Check.Readability.MultiAlias, []},
+          {Credo.Check.Readability.SeparateAliasRequire, []},
+          {Credo.Check.Readability.SinglePipe, []},
+          {Credo.Check.Readability.Specs, false},
+          {Credo.Check.Readability.StrictModuleLayout, []},
+          {Credo.Check.Readability.WithCustomTaggedTuple, []},
+          {Credo.Check.Refactor.ABCSize, []},
+          {Credo.Check.Refactor.AppendSingleItem, []},
+          {Credo.Check.Refactor.DoubleBooleanNegation, []},
+          {Credo.Check.Refactor.ModuleDependencies, []},
+          {Credo.Check.Refactor.NegatedIsNil, []},
+          {Credo.Check.Refactor.PipeChainStart, []},
+          {Credo.Check.Refactor.VariableRebinding, []},
+          {Credo.Check.Warning.LeakyEnvironment, []},
+          {Credo.Check.Warning.MapGetUnsafePass, []},
+          {Credo.Check.Warning.UnsafeToAtom, []}
+        ],
+        disabled: [
+          #
+          # Checks scheduled for next check update (opt-in for now, just replace `false` with `[]`)
+
+          #
+          # Controversial and experimental checks (opt-in, just move the check to `:enabled`
+          #  and be sure to use `mix credo --strict` to see low priority checks)
+          #
+          {Credo.Check.Refactor.MapInto, false},
+
+          #
+          # Deprecated checks (these will be deleted after a grace period)
+          #
+          {Credo.Check.Warning.MapGetUnsafePass, false},
+          {Credo.Check.Warning.UnsafeToAtom, false}
+        ]
+      }
+    }
+  ]
+}

--- a/test/dns_packet_test.exs
+++ b/test/dns_packet_test.exs
@@ -98,17 +98,19 @@ defmodule DNSpacketTest do
       rdata = %{
         mname: "ns1.example.com",
         rname: "admin.example.com",
+        # credo:disable-for-next-line Credo.Check.Readability.LargeNumbers
         serial: 2023010101,
         refresh: 7200,
         retry: 3600,
-        expire: 604800,
-        minimum: 86400
+        expire: 604_800,
+        minimum: 86_400
       }
       result = DNSpacket.create_rdata(rdata, :soa, :in)
       
       expected = <<3, "ns1", 7, "example", 3, "com">> <>
                 <<5, "admin", 7, "example", 3, "com">> <>
-                <<2023010101::32, 7200::32, 3600::32, 604800::32, 86400::32>>
+                # credo:disable-for-next-line Credo.Check.Readability.LargeNumbers
+                <<2023010101::32, 7200::32, 3600::32, 604_800::32, 86_400::32>>
       assert result == expected
     end
   end
@@ -415,12 +417,14 @@ defmodule DNSpacketTest do
     test "parse_rdata for SOA record" do
       soa_binary = <<3, "ns1", 7, "example", 3, "com", 0>> <>
                    <<5, "admin", 7, "example", 3, "com", 0>> <>
-                   <<2023010101::32, 7200::32, 3600::32, 604800::32, 86400::32>>
+                   # credo:disable-for-next-line Credo.Check.Readability.LargeNumbers
+                   <<2023010101::32, 7200::32, 3600::32, 604_800::32, 86_400::32>>
       orig_body = <<0::96>> <> soa_binary
       
       result = DNSpacket.parse_rdata(soa_binary, :soa, :in, orig_body)
       assert result.mname == "ns1.example.com."
       assert result.rname == "admin.example.com."
+      # credo:disable-for-next-line Credo.Check.Readability.LargeNumbers
       assert result.serial == 2023010101
     end
 
@@ -556,8 +560,8 @@ defmodule DNSpacketTest do
       
       # Test with pre-existing result
       existing = [%{code: :test, data: <<1, 2>>}]
-      result = DNSpacket.parse_opt_rr(existing, <<>>)
-      assert result == existing
+      result2 = DNSpacket.parse_opt_rr(existing, <<>>)
+      assert result2 == existing
     end
 
     test "parse_opt_code with extended DNS error different format" do
@@ -601,11 +605,11 @@ defmodule DNSpacketTest do
             rdata: %{addr: {0x2001, 0xdb8, 0, 0, 0, 0, 0, 2}}}
         ],
         authority: [
-          %{name: "example.com.", type: :ns, class: :in, ttl: 86400,
+          %{name: "example.com.", type: :ns, class: :in, ttl: 86_400,
             rdata: %{name: "ns1.example.com."}}
         ],
         additional: [
-          %{name: "ns1.example.com.", type: :a, class: :in, ttl: 86400,
+          %{name: "ns1.example.com.", type: :a, class: :in, ttl: 86_400,
             rdata: %{addr: {10, 0, 0, 10}}}
         ]
       }
@@ -629,9 +633,9 @@ defmodule DNSpacketTest do
       assert result == <<9, "localhost">>
       
       # Test domain with empty label (edge case)
-      result = DNSpacket.create_domain_name("test..com")
+      result2 = DNSpacket.create_domain_name("test..com")
       expected = <<4, "test", 0, 3, "com">>
-      assert result == expected
+      assert result2 == expected
     end
 
     test "create_character_string with maximum length" do


### PR DESCRIPTION
## Summary
- Improve code quality by addressing all Credo warnings and suggestions
- Configure Credo with custom settings for the project
- Achieve clean Credo output with no remaining issues

## Changes
- Add @moduledoc documentation to DNSpacket module
- Add @type t() definition for proper struct typespec
- Fix code style issues (spaces after commas, variable naming)
- Extract duplicate OPT record parsing logic into helper functions
- Configure .credo.exs with appropriate settings for the project
- Add targeted credo:disable comments for intentional design choices

🤖 Generated with [Claude Code](https://claude.ai/code)