### PR TITLE
Implement structured EDNS parsing and improve test coverage

### DIFF
--- a/lib/dns.ex
+++ b/lib/dns.ex
@@ -99,9 +99,9 @@ defmodule DNS do
   @rcode_code_map for {k, v} <- @rcode_map, into: %{}, do: {v, k}
 
   @option_map %{
-    0 => :reserved0,
+    0 => :reserved,
     1 => :llq,
-    2 => :ul,
+    2 => :update_lease,
     3 => :nsid,
     4 => :reserved4,
     5 => :dau,
@@ -117,6 +117,9 @@ defmodule DNS do
     15 => :extended_dns_error,
     16 => :edns_client_tag,
     17 => :edns_server_tag,
+    18 => :report_channel,
+    19 => :zoneversion,
+    20_292 => :umbrella_ident,
     26_946 => :deviceid
   }
 
@@ -143,7 +146,7 @@ defmodule DNS do
   def type_code(:any), do: 255
   def type_code(atom), do: Map.get(@type_code_map, atom)
 
-  # Optimized pattern matching for most common DNS classes with inlining  
+  # Optimized pattern matching for most common DNS classes with inlining
   def class(1), do: :in
   def class(255), do: :any
   def class(code), do: Map.get(@class_map, code)
@@ -187,11 +190,11 @@ defmodule DNS do
     :badtrunc => "Bad Truncation",
     :badcookie => "Bad/missing Server Cookie"
   }
-  
-  def rcode_text(), do: @rcode_text
 
-  def port(), do: @default_port
-  def service(), do: @default_service
+  def rcode_text, do: @rcode_text
 
-  def edns_max_udpsize(), do: 1232
+  def port, do: @default_port
+  def service, do: @default_service
+
+  def edns_max_udpsize, do: 1232
 end

--- a/test/dns_packet_test.exs
+++ b/test/dns_packet_test.exs
@@ -1,5 +1,6 @@
 defmodule DNSpacketTest do
   use ExUnit.Case
+  import Bitwise
 
   describe "create_domain_name/1" do
     test "creates domain name binary for simple domain" do
@@ -106,12 +107,33 @@ defmodule DNSpacketTest do
         minimum: 86_400
       }
       result = DNSpacket.create_rdata(rdata, :soa, :in)
-      
+
       expected = <<3, "ns1", 7, "example", 3, "com">> <>
                 <<5, "admin", 7, "example", 3, "com">> <>
                 # credo:disable-for-next-line Credo.Check.Readability.LargeNumbers
                 <<2023010101::32, 7200::32, 3600::32, 604_800::32, 86_400::32>>
       assert result == expected
+    end
+
+    test "creates HINFO record rdata" do
+      rdata = %{cpu: "i386", os: "linux"}
+      result = DNSpacket.create_rdata(rdata, :hinfo, :in)
+      expected = <<4, "i386", 5, "linux">>
+      assert result == expected
+    end
+
+    test "creates CAA record rdata" do
+      rdata = %{flag: 0, tag: "issue", value: "letsencrypt.org"}
+      result = DNSpacket.create_rdata(rdata, :caa, :in)
+      expected = <<0, 5, "issue", "letsencrypt.org">>
+      assert result == expected
+    end
+
+    test "creates rdata for unknown record type" do
+      # Test the fallback case
+      rdata = <<1, 2, 3, 4, 5>>
+      result = DNSpacket.create_rdata(rdata, :unknown_type, :in)
+      assert result == rdata
     end
   end
 
@@ -205,9 +227,9 @@ defmodule DNSpacketTest do
     end
 
     test "parses extended DNS error option" do
-      data = <<15::16, 8::16, 18::16, "Blocked">>
+      data = <<18::16, "Blocked">>  # info_code + txt
       result = DNSpacket.parse_opt_code(:extended_dns_error, data)
-      expected = %{code: :extended_dns_error, option_code: 15, info_code: 18, txt: "Blocked"}
+      expected = %{code: :extended_dns_error, info_code: 18, txt: "Blocked"}
       assert result == expected
     end
 
@@ -215,6 +237,142 @@ defmodule DNSpacketTest do
       data = <<1, 2, 3, 4>>
       result = DNSpacket.parse_opt_code(:unknown, data)
       expected = %{code: :unknown, data: <<1, 2, 3, 4>>}
+      assert result == expected
+    end
+
+    test "parses DAU option" do
+      data = <<7, 8, 10>>
+      result = DNSpacket.parse_opt_code(:dau, data)
+      expected = %{code: :dau, algorithms: [7, 8, 10]}
+      assert result == expected
+    end
+
+    test "parses DHU option" do
+      data = <<1, 2>>
+      result = DNSpacket.parse_opt_code(:dhu, data)
+      expected = %{code: :dhu, algorithms: [1, 2]}
+      assert result == expected
+    end
+
+    test "parses N3U option" do
+      data = <<1>>
+      result = DNSpacket.parse_opt_code(:n3u, data)
+      expected = %{code: :n3u, algorithms: [1]}
+      assert result == expected
+    end
+
+    test "parses EDNS expire option with value" do
+      data = <<0, 0, 14, 16>>  # 3600 in binary
+      result = DNSpacket.parse_opt_code(:edns_expire, data)
+      expected = %{code: :edns_expire, expire: 3600}
+      assert result == expected
+    end
+
+    test "parses EDNS expire option without value" do
+      result = DNSpacket.parse_opt_code(:edns_expire, <<>>)
+      expected = %{code: :edns_expire, expire: nil}
+      assert result == expected
+    end
+
+    test "parses chain option" do
+      data = "example.com"
+      result = DNSpacket.parse_opt_code(:chain, data)
+      expected = %{code: :chain, closest_encloser: "example.com"}
+      assert result == expected
+    end
+
+    test "parses EDNS key tag option" do
+      data = <<48, 57, 212, 49>>  # Two 16-bit tags: 12345 and 54321
+      result = DNSpacket.parse_opt_code(:edns_key_tag, data)
+      expected = %{code: :edns_key_tag, key_tags: [12_345, 54_321]}
+      assert result == expected
+    end
+
+    test "parses EDNS client tag option" do
+      data = <<4, 210>>  # 1234 in binary
+      result = DNSpacket.parse_opt_code(:edns_client_tag, data)
+      expected = %{code: :edns_client_tag, tag: 1234}
+      assert result == expected
+    end
+
+    test "parses EDNS server tag option" do
+      data = <<22, 46>>  # 5678 in binary
+      result = DNSpacket.parse_opt_code(:edns_server_tag, data)
+      expected = %{code: :edns_server_tag, tag: 5678}
+      assert result == expected
+    end
+
+    test "parses report channel option" do
+      data = "agent.example.com"
+      result = DNSpacket.parse_opt_code(:report_channel, data)
+      expected = %{code: :report_channel, agent_domain: "agent.example.com"}
+      assert result == expected
+    end
+
+    test "parses zoneversion option" do
+      data = <<0, 4, 98, 213, 60, 138, 186, 192>>  # 1_234_567_890_123_456 in binary
+      result = DNSpacket.parse_opt_code(:zoneversion, data)
+      expected = %{code: :zoneversion, version: 1_234_567_890_123_456}
+      assert result == expected
+    end
+
+    test "parses update lease option" do
+      data = <<0, 0, 28, 32>>  # 7200 in binary
+      result = DNSpacket.parse_opt_code(:update_lease, data)
+      expected = %{code: :update_lease, lease: 7200}
+      assert result == expected
+    end
+
+    test "parses LLQ option" do
+      data = <<0, 1,  # version: 1
+               0, 1,  # llq_opcode: 1
+               0, 0,  # error_code: 0
+               0, 4, 98, 213, 60, 138, 186, 192,  # llq_id: 1_234_567_890_123_456
+               0, 0, 14, 16>>  # lease_life: 3600
+      result = DNSpacket.parse_opt_code(:llq, data)
+      expected = %{
+        code: :llq,
+        version: 1,
+        llq_opcode: 1,
+        error_code: 0,
+        llq_id: 1_234_567_890_123_456,
+        lease_life: 3600
+      }
+      assert result == expected
+    end
+
+    test "parses umbrella ident option" do
+      data = <<18, 52, 86, 120>>  # 0x12345678 in binary
+      result = DNSpacket.parse_opt_code(:umbrella_ident, data)
+      expected = %{code: :umbrella_ident, ident: 0x12345678}
+      assert result == expected
+    end
+
+    test "parses deviceid option" do
+      data = "device123"
+      result = DNSpacket.parse_opt_code(:deviceid, data)
+      expected = %{code: :deviceid, device_id: "device123"}
+      assert result == expected
+    end
+
+    test "parses NSID option" do
+      data = "ns1.example.com"
+      result = DNSpacket.parse_opt_code(:nsid, data)
+      expected = %{code: :nsid, data: "ns1.example.com"}
+      assert result == expected
+    end
+
+    test "parses TCP keepalive option" do
+      data = <<100::16>>
+      result = DNSpacket.parse_opt_code(:edns_tcp_keepalive, data)
+      expected = %{code: :edns_tcp_keepalive, data: <<100::16>>}
+      assert result == expected
+    end
+
+    test "parses padding option" do
+      data = <<0, 0, 0, 0>>
+      result = DNSpacket.parse_opt_code(:padding, data)
+      expected = %{code: :padding, data: <<0, 0, 0, 0>>}
       assert result == expected
     end
   end
@@ -300,7 +458,7 @@ defmodule DNSpacketTest do
         0x00, 0x04,  # RDLENGTH = 4
         192, 168, 1, 1  # IP address
       >>
-      
+
       parsed = DNSpacket.parse(compressed_packet)
       assert parsed.id == 0x1234
       assert hd(parsed.answer).name == "example.com."
@@ -321,7 +479,7 @@ defmodule DNSpacketTest do
         0x00, 0x01,  # QTYPE = A
         0x00, 0x01   # QCLASS = IN
       >>
-      
+
       parsed = DNSpacket.parse(root_packet)
       assert hd(parsed.question).qname == "."
     end
@@ -348,7 +506,7 @@ defmodule DNSpacketTest do
         0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x01, 0x2C, 0x00, 0x04,
         192, 168, 1, 2
       >>
-      
+
       parsed = DNSpacket.parse(multi_compressed)
       assert length(parsed.answer) == 2
       # Note: Order might vary, so check both names are present
@@ -388,12 +546,11 @@ defmodule DNSpacketTest do
       assert result == expected
     end
 
-
     test "parse_rdata for NS record" do
       # Create a binary with NS record data
       ns_binary = <<3, "ns1", 7, "example", 3, "com", 0>>
       orig_body = <<0::96>> <> ns_binary  # Add padding for pointer parsing
-      
+
       result = DNSpacket.parse_rdata(ns_binary, :ns, :in, orig_body)
       assert result.name == "ns1.example.com."
     end
@@ -401,7 +558,7 @@ defmodule DNSpacketTest do
     test "parse_rdata for CNAME record" do
       cname_binary = <<5, "alias", 7, "example", 3, "com", 0>>
       orig_body = <<0::96>> <> cname_binary
-      
+
       result = DNSpacket.parse_rdata(cname_binary, :cname, :in, orig_body)
       assert result.name == "alias.example.com."
     end
@@ -409,7 +566,7 @@ defmodule DNSpacketTest do
     test "parse_rdata for PTR record" do
       ptr_binary = <<4, "host", 7, "example", 3, "com", 0>>
       orig_body = <<0::96>> <> ptr_binary
-      
+
       result = DNSpacket.parse_rdata(ptr_binary, :ptr, :in, orig_body)
       assert result.name == "host.example.com."
     end
@@ -420,7 +577,7 @@ defmodule DNSpacketTest do
                    # credo:disable-for-next-line Credo.Check.Readability.LargeNumbers
                    <<2023010101::32, 7200::32, 3600::32, 604_800::32, 86_400::32>>
       orig_body = <<0::96>> <> soa_binary
-      
+
       result = DNSpacket.parse_rdata(soa_binary, :soa, :in, orig_body)
       assert result.mname == "ns1.example.com."
       assert result.rname == "admin.example.com."
@@ -431,7 +588,7 @@ defmodule DNSpacketTest do
     test "parse_rdata for MX record" do
       mx_binary = <<10::16>> <> <<4, "mail", 7, "example", 3, "com", 0>>
       orig_body = <<0::96>> <> mx_binary
-      
+
       result = DNSpacket.parse_rdata(mx_binary, :mx, :in, orig_body)
       assert result.preference == 10
       assert result.name == "mail.example.com."
@@ -440,19 +597,81 @@ defmodule DNSpacketTest do
     test "parse_opt_rr with multiple options" do
       opt_data = <<8::16, 4::16, 1, 2, 3, 4>> <>  # ECS option
                  <<10::16, 8::16, 1, 2, 3, 4, 5, 6, 7, 8>>  # Cookie option
-      
+
       result = DNSpacket.parse_opt_rr([], opt_data)
       assert length(result) == 2
     end
 
+    test "parse_opt_rr with all supported EDNS options" do
+      # Build comprehensive opt_data with many options
+      opt_data =
+        # ECS option (code 8)
+        <<8::16, 7::16, 1::16, 24::8, 0::8, 192, 168, 1>> <>
+        # Cookie option (code 10)
+        <<10::16, 16::16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16>> <>
+        # NSID option (code 3)
+        <<3::16, 6::16, "server">> <>
+        # Extended DNS Error (code 15)
+        <<15::16, 9::16, 18::16, "Blocked">> <>
+        # TCP Keepalive (code 11)
+        <<11::16, 2::16, 300::16>> <>
+        # Padding (code 12)
+        <<12::16, 4::16, 0::32>> <>
+        # DAU (code 5)
+        <<5::16, 3::16, 7, 8, 10>> <>
+        # DHU (code 6)
+        <<6::16, 2::16, 1, 2>> <>
+        # N3U (code 7)
+        <<7::16, 1::16, 1>> <>
+        # EDNS Expire (code 9)
+        <<9::16, 4::16, 3600::32>> <>
+        # Chain (code 13)
+        <<13::16, 11::16, "example.com">> <>
+        # EDNS Key Tag (code 14)
+        <<14::16, 4::16, 12_345::16, 54_321::16>> <>
+        # EDNS Client Tag (code 16)
+        <<16::16, 2::16, 1234::16>> <>
+        # EDNS Server Tag (code 17)
+        <<17::16, 2::16, 5678::16>> <>
+        # Report Channel (code 18)
+        <<18::16, 17::16, "agent.example.com">> <>
+        # Zone Version (code 19)
+        <<19::16, 8::16, 0, 4, 98, 213, 60, 138, 186, 192>> <>
+        # Update Lease (code 2)
+        <<2::16, 4::16, 7200::32>> <>
+        # LLQ (code 1)
+        <<1::16, 18::16, 1::16, 1::16, 0::16, 0, 4, 98, 213, 60, 138, 186, 192, 3600::32>> <>
+        # Umbrella Ident (code 20292)
+        <<20_292::16, 4::16, 0x12345678::32>> <>
+        # DeviceID (code 26946)
+        <<26_946::16, 9::16, "device123">>
+
+      result = DNSpacket.parse_opt_rr([], opt_data)
+
+      # Should parse all 20 options
+      assert length(result) == 20
+
+      # Verify a few specific options
+      ecs_opt = Enum.find(result, &(&1.code == :edns_client_subnet))
+      assert ecs_opt.family == 1
+      assert ecs_opt.source == 24
+
+      cookie_opt = Enum.find(result, &(&1.code == :cookie))
+      assert byte_size(cookie_opt.cookie) == 16
+
+      llq_opt = Enum.find(result, &(&1.code == :llq))
+      assert llq_opt.version == 1
+      assert llq_opt.llq_id == 1_234_567_890_123_456
+    end
+
     test "create_answer with multiple answers" do
       answers = [
-        %{name: "test.com.", type: :a, class: :in, ttl: 300, 
+        %{name: "test.com.", type: :a, class: :in, ttl: 300,
           rdata: %{addr: {192, 168, 1, 1}}},
         %{name: "test.com.", type: :a, class: :in, ttl: 300,
           rdata: %{addr: {192, 168, 1, 2}}}
       ]
-      
+
       result = DNSpacket.create_answer(answers)
       assert is_binary(result)
       assert byte_size(result) > 0
@@ -463,7 +682,7 @@ defmodule DNSpacketTest do
         %{qname: "test1.com.", qtype: :a, qclass: :in},
         %{qname: "test2.com.", qtype: :aaaa, qclass: :in}
       ]
-      
+
       result = DNSpacket.create_question(questions)
       assert is_binary(result)
       assert byte_size(result) > 0
@@ -472,14 +691,14 @@ defmodule DNSpacketTest do
     test "create packet with all header flags set" do
       packet = %DNSpacket{
         id: 0x1234,
-        qr: 1, opcode: 15, aa: 1, tc: 1, rd: 1, 
+        qr: 1, opcode: 15, aa: 1, tc: 1, rd: 1,
         ra: 1, z: 1, ad: 1, cd: 1, rcode: 15,
         question: []
       }
-      
+
       binary = DNSpacket.create(packet)
       parsed = DNSpacket.parse(binary)
-      
+
       assert parsed.qr == 1
       assert parsed.opcode == 15
       assert parsed.aa == 1
@@ -517,7 +736,7 @@ defmodule DNSpacketTest do
         0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x01, 0x2C, 0x00, 0x04,
         192, 168, 1, 1
       >>
-      
+
       parsed = DNSpacket.parse(complex_packet)
       assert hd(parsed.question).qname == "sub.sub.sub.example.com."
       assert hd(parsed.answer).name == "sub.sub.sub.example.com."
@@ -536,7 +755,7 @@ defmodule DNSpacketTest do
         0x00, 0x01,  # QTYPE = A
         0x00, 0x01   # QCLASS = IN
       >>
-      
+
       parsed = DNSpacket.parse(root_packet)
       assert hd(parsed.question).qname == "."
     end
@@ -557,7 +776,7 @@ defmodule DNSpacketTest do
       # Test parse_opt_rr with empty binary
       result = DNSpacket.parse_opt_rr([], <<>>)
       assert result == []
-      
+
       # Test with pre-existing result
       existing = [%{code: :test, data: <<1, 2>>}]
       result2 = DNSpacket.parse_opt_rr(existing, <<>>)
@@ -566,9 +785,8 @@ defmodule DNSpacketTest do
 
     test "parse_opt_code with extended DNS error different format" do
       # Test different format of extended DNS error
-      data = <<5::16, 4::16, 12::16, "Bad">>
+      data = <<12::16, "Bad">>
       result = DNSpacket.parse_opt_code(:extended_dns_error, data)
-      assert result.option_code == 5
       assert result.info_code == 12
       assert result.txt == "Bad"
     end
@@ -584,7 +802,7 @@ defmodule DNSpacketTest do
 
     test "create_rdata for all supported types complete coverage" do
       # Test create_rdata edge cases and ensure all paths are covered
-      
+
       # Test AAAA with different IPv6 format
       rdata = %{addr: {0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff}}
       result = DNSpacket.create_rdata(rdata, :aaaa, :in)
@@ -599,7 +817,7 @@ defmodule DNSpacketTest do
         qr: 1, aa: 1, rd: 1, ra: 1,
         question: [%{qname: "test.example.com.", qtype: :a, qclass: :in}],
         answer: [
-          %{name: "test.example.com.", type: :a, class: :in, ttl: 300, 
+          %{name: "test.example.com.", type: :a, class: :in, ttl: 300,
             rdata: %{addr: {10, 0, 0, 1}}},
           %{name: "test.example.com.", type: :aaaa, class: :in, ttl: 300,
             rdata: %{addr: {0x2001, 0xdb8, 0, 0, 0, 0, 0, 2}}}
@@ -613,10 +831,10 @@ defmodule DNSpacketTest do
             rdata: %{addr: {10, 0, 0, 10}}}
         ]
       }
-      
+
       binary = DNSpacket.create(packet)
       parsed = DNSpacket.parse(binary)
-      
+
       assert parsed.id == 0x9999
       assert length(parsed.answer) == 2
       assert length(parsed.authority) == 1
@@ -627,11 +845,11 @@ defmodule DNSpacketTest do
       # Test edge cases for domain name creation
       assert DNSpacket.create_domain_name("") == <<0>>
       assert DNSpacket.create_domain_name(".") == <<0, 0>>
-      
+
       # Test single label
       result = DNSpacket.create_domain_name("localhost")
       assert result == <<9, "localhost">>
-      
+
       # Test domain with empty label (edge case)
       result2 = DNSpacket.create_domain_name("test..com")
       expected = <<4, "test", 0, 3, "com">>
@@ -649,7 +867,7 @@ defmodule DNSpacketTest do
       # Create packet with OPT record to test the non-fast parse path coverage
       packet_with_opt = <<
         0x12, 0x34,  # ID
-        0x00, 0x00,  # Flags  
+        0x00, 0x00,  # Flags
         0x00, 0x00,  # QDCOUNT = 0
         0x00, 0x00,  # ANCOUNT = 0
         0x00, 0x00,  # NSCOUNT = 0
@@ -663,7 +881,7 @@ defmodule DNSpacketTest do
         0x80, 0x00,             # Flags (DNSSEC OK)
         0x00, 0x00              # RDLENGTH = 0
       >>
-      
+
       parsed = DNSpacket.parse(packet_with_opt)
       assert length(parsed.additional) == 1
       opt_record = hd(parsed.additional)
@@ -672,22 +890,123 @@ defmodule DNSpacketTest do
       assert opt_record.dnssec == 1
     end
 
+    test "create_rr for OPT record with various EDNS options" do
+      # Test create_rr with different option formats
+      opt_record = %{
+        type: :opt,
+        payload_size: 4096,
+        ex_rcode: 0,
+        version: 0,
+        dnssec: 1,
+        z: 0,
+        rdata: [
+          %{code: :edns_client_subnet, family: 1, source: 24, scope: 0, addr: <<192, 168, 1>>},
+          %{code: :cookie, cookie: <<1, 2, 3, 4, 5, 6, 7, 8>>},
+          %{code: :nsid, data: "server1"},
+          %{code: :extended_dns_error, info_code: 18, txt: "Blocked"},
+          %{code: :edns_tcp_keepalive, data: <<300::16>>},
+          %{code: :padding, data: <<0, 0, 0, 0>>},
+          %{code: :dau, algorithms: [7, 8, 10]},
+          %{code: :dhu, algorithms: [1, 2]},
+          %{code: :n3u, algorithms: [1]},
+          %{code: :edns_expire, expire: 3600},
+          %{code: :edns_expire, expire: nil},
+          %{code: :chain, closest_encloser: "example.com"},
+          %{code: :edns_key_tag, key_tags: [12_345, 54_321]},
+          %{code: :edns_client_tag, tag: 1234},
+          %{code: :edns_server_tag, tag: 5678},
+          %{code: :report_channel, agent_domain: "agent.example.com"},
+          %{code: :zoneversion, version: 1_234_567_890_123_456},
+          %{code: :update_lease, lease: 7200},
+          %{code: :llq, version: 1, llq_opcode: 1, error_code: 0, llq_id: 1_234_567_890_123_456, lease_life: 3600},
+          %{code: :umbrella_ident, ident: 0x12345678},
+          %{code: :deviceid, device_id: "device123"},
+          %{code: :unknown_test, data: <<1, 2, 3, 4>>}
+        ]
+      }
+
+      binary = DNSpacket.create_rr(opt_record)
+
+      # Verify the binary starts with OPT record header
+      <<0, 41::16, payload_size::16, ex_rcode::8, version::8, flags::16, rdlength::16, _rdata::binary>> = binary
+      assert payload_size == 4096
+      assert ex_rcode == 0
+      assert version == 0
+      assert (flags >>> 15) == 1  # DNSSEC bit
+      assert rdlength > 0  # Should have RDATA for all the options
+    end
+
+    test "create_rr for OPT record with empty rdata list" do
+      opt_record = %{
+        type: :opt,
+        payload_size: 512,
+        ex_rcode: 0,
+        version: 0,
+        dnssec: 0,
+        z: 0,
+        rdata: []
+      }
+
+      binary = DNSpacket.create_rr(opt_record)
+
+      # Should create valid OPT record with no options
+      <<0, 41::16, 512::16, 0, 0, 0::16, 0::16>> = binary
+    end
+
+    test "create_rr for normal DNS records" do
+      # Test A record
+      a_record = %{
+        name: "example.com.",
+        type: :a,
+        class: :in,
+        ttl: 300,
+        rdata: %{addr: {192, 168, 1, 1}}
+      }
+
+      a_binary = DNSpacket.create_rr(a_record)
+      assert is_binary(a_binary)
+
+      # Test MX record
+      mx_record = %{
+        name: "example.com.",
+        type: :mx,
+        class: :in,
+        ttl: 3600,
+        rdata: %{preference: 10, name: "mail.example.com."}
+      }
+
+      mx_binary = DNSpacket.create_rr(mx_record)
+      assert is_binary(mx_binary)
+
+      # Test TXT record
+      txt_record = %{
+        name: "example.com.",
+        type: :txt,
+        class: :in,
+        ttl: 300,
+        rdata: %{txt: "v=spf1 include:_spf.example.com ~all"}
+      }
+
+      txt_binary = DNSpacket.create_rr(txt_record)
+      assert is_binary(txt_binary)
+    end
+
     test "parse packet with authority and additional sections" do
       packet = %DNSpacket{
         id: 0x5678,
         qr: 1, aa: 1,
         question: [%{qname: "test.com.", qtype: :a, qclass: :in}],
-        answer: [%{name: "test.com.", type: :a, class: :in, ttl: 300, 
+        answer: [%{name: "test.com.", type: :a, class: :in, ttl: 300,
                    rdata: %{addr: {192, 168, 1, 1}}}],
         authority: [%{name: "test.com.", type: :ns, class: :in, ttl: 3600,
                       rdata: %{name: "ns1.test.com."}}],
         additional: [%{name: "ns1.test.com.", type: :a, class: :in, ttl: 3600,
                        rdata: %{addr: {192, 168, 1, 10}}}]
       }
-      
+
       binary = DNSpacket.create(packet)
       parsed = DNSpacket.parse(binary)
-      
+
       assert length(parsed.authority) == 1
       assert length(parsed.additional) == 1
       assert hd(parsed.authority).type == :ns
@@ -698,10 +1017,10 @@ defmodule DNSpacketTest do
   describe "parse_edns_info/1" do
     test "returns nil when no OPT record present" do
       additional = [
-        %{name: "ns1.example.com.", type: :a, class: :in, ttl: 300, 
+        %{name: "ns1.example.com.", type: :a, class: :in, ttl: 300,
           rdata: %{addr: {192, 168, 1, 1}}}
       ]
-      
+
       result = DNSpacket.parse_edns_info(additional)
       assert result == nil
     end
@@ -719,7 +1038,7 @@ defmodule DNSpacketTest do
           rdata: []
         }
       ]
-      
+
       result = DNSpacket.parse_edns_info(additional)
       assert result.payload_size == 1232
       assert result.ex_rcode == 0
@@ -743,7 +1062,7 @@ defmodule DNSpacketTest do
           ]
         }
       ]
-      
+
       result = DNSpacket.parse_edns_info(additional)
       assert result.options.ecs.family == 1
       assert result.options.ecs.client_subnet == {192, 168, 1, 0}
@@ -756,12 +1075,12 @@ defmodule DNSpacketTest do
         %{
           type: :opt,
           rdata: [
-            %{code: :edns_client_subnet, family: 2, source: 48, scope: 0, 
+            %{code: :edns_client_subnet, family: 2, source: 48, scope: 0,
               addr: <<0x2001::16, 0xdb8::16, 0x1234::16>>}
           ]
         }
       ]
-      
+
       result = DNSpacket.parse_edns_info(additional)
       assert result.options.ecs.family == 2
       assert result.options.ecs.client_subnet == {0x2001, 0xdb8, 0x1234, 0, 0, 0, 0, 0}
@@ -777,7 +1096,7 @@ defmodule DNSpacketTest do
           ]
         }
       ]
-      
+
       result = DNSpacket.parse_edns_info(additional)
       assert result.options.cookie.client == <<1, 2, 3, 4, 5, 6, 7, 8>>
       assert result.options.cookie.server == nil
@@ -787,7 +1106,7 @@ defmodule DNSpacketTest do
       client_cookie = <<1, 2, 3, 4, 5, 6, 7, 8>>
       server_cookie = <<9, 10, 11, 12, 13, 14, 15, 16>>
       full_cookie = client_cookie <> server_cookie
-      
+
       additional = [
         %{
           type: :opt,
@@ -796,10 +1115,46 @@ defmodule DNSpacketTest do
           ]
         }
       ]
-      
+
       result = DNSpacket.parse_edns_info(additional)
       assert result.options.cookie.client == client_cookie
       assert result.options.cookie.server == server_cookie
+    end
+
+    test "parses cookie option - invalid size" do
+      # Test with cookie that's too small (< 8 bytes)
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :cookie, cookie: <<1, 2, 3, 4>>}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      assert result.options.cookie.client == <<1, 2, 3, 4>>
+      assert result.options.cookie.server == nil
+    end
+
+    test "parses cookie option - maximum size" do
+      # Test with maximum cookie size (40 bytes = 8 client + 32 server)
+      client_cookie = <<1, 2, 3, 4, 5, 6, 7, 8>>
+      server_cookie = <<9::size(32 * 8)>>  # 32 bytes of 9s
+      full_cookie = client_cookie <> server_cookie
+
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :cookie, cookie: full_cookie}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      assert result.options.cookie.client == client_cookie
+      assert byte_size(result.options.cookie.server) == 32
     end
 
     test "parses NSID option with ASCII text" do
@@ -812,7 +1167,7 @@ defmodule DNSpacketTest do
           ]
         }
       ]
-      
+
       result = DNSpacket.parse_edns_info(additional)
       assert result.options.nsid == nsid_data
     end
@@ -827,7 +1182,7 @@ defmodule DNSpacketTest do
           ]
         }
       ]
-      
+
       result = DNSpacket.parse_edns_info(additional)
       assert result.options.nsid == "fffefd"
     end
@@ -841,7 +1196,7 @@ defmodule DNSpacketTest do
           ]
         }
       ]
-      
+
       result = DNSpacket.parse_edns_info(additional)
       assert result.options.extended_dns_error.info_code == 18
       assert result.options.extended_dns_error.extra_text == "Blocked by policy"
@@ -856,7 +1211,7 @@ defmodule DNSpacketTest do
           ]
         }
       ]
-      
+
       result = DNSpacket.parse_edns_info(additional)
       assert result.options.tcp_keepalive.timeout == 300
     end
@@ -870,9 +1225,25 @@ defmodule DNSpacketTest do
           ]
         }
       ]
-      
+
       result = DNSpacket.parse_edns_info(additional)
       assert result.options.tcp_keepalive.timeout == nil
+    end
+
+    test "parses TCP keepalive option with invalid data length" do
+      # Test with non-standard data length (not 0 or 2 bytes)
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :edns_tcp_keepalive, data: <<1, 2, 3>>}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      assert result.options.tcp_keepalive.timeout == nil
+      assert result.options.tcp_keepalive.raw_data == <<1, 2, 3>>
     end
 
     test "parses padding option" do
@@ -885,7 +1256,7 @@ defmodule DNSpacketTest do
           ]
         }
       ]
-      
+
       result = DNSpacket.parse_edns_info(additional)
       assert result.options.padding.length == 8
     end
@@ -900,7 +1271,7 @@ defmodule DNSpacketTest do
           ]
         }
       ]
-      
+
       result = DNSpacket.parse_edns_info(additional)
       assert length(result.options.unknown) == 2
     end
@@ -918,7 +1289,7 @@ defmodule DNSpacketTest do
           ]
         }
       ]
-      
+
       result = DNSpacket.parse_edns_info(additional)
       assert result.payload_size == 4096
       assert result.options.ecs.client_subnet == {10, 0, 0, 0}
@@ -938,7 +1309,7 @@ defmodule DNSpacketTest do
           ]
         }
       ]
-      
+
       result = DNSpacket.parse_edns_info(additional)
       assert result.options.ecs.client_subnet == {0, 0, 0, 0}
     end
@@ -952,7 +1323,7 @@ defmodule DNSpacketTest do
           ]
         }
       ]
-      
+
       result = DNSpacket.parse_edns_info(additional)
       assert result.options.ecs.client_subnet == {0, 0, 0, 0, 0, 0, 0, 0}
     end
@@ -966,10 +1337,65 @@ defmodule DNSpacketTest do
           ]
         }
       ]
-      
+
       result = DNSpacket.parse_edns_info(additional)
       # Should mask out bits beyond prefix length
       assert result.options.ecs.client_subnet == {203, 128, 0, 0}
+    end
+
+    test "handles IPv6 with partial bytes and masking" do
+      # Test IPv6 with prefix that requires masking mid-byte
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :edns_client_subnet, family: 2, source: 36, scope: 0,
+              addr: <<0x20, 0x01, 0x0d, 0xb8, 0xFF>>}  # 5 bytes for /36 prefix
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      # Should mask the last 4 bits of the 5th byte
+      assert elem(result.options.ecs.client_subnet, 0) == 0x2001
+      assert elem(result.options.ecs.client_subnet, 1) == 0x0db8
+      assert elem(result.options.ecs.client_subnet, 2) == 0xF000  # Masked
+    end
+
+    test "handles IPv4 address that's too long" do
+      # Test when address bytes exceed what's needed for IPv4
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :edns_client_subnet, family: 1, source: 32, scope: 0,
+              addr: <<192, 168, 1, 1, 5, 6>>}  # 6 bytes, but IPv4 only needs 4
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      # Should truncate to 4 bytes
+      assert result.options.ecs.client_subnet == {192, 168, 1, 1}
+    end
+
+    test "handles IPv6 address that's too long" do
+      # Test when address bytes exceed what's needed for IPv6
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :edns_client_subnet, family: 2, source: 128, scope: 0,
+              # 18 bytes, but IPv6 only needs 16
+              addr: <<0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF>>}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      # Should truncate to 16 bytes and parse as IPv6
+      assert elem(result.options.ecs.client_subnet, 0) == 0x2001
+      assert elem(result.options.ecs.client_subnet, 1) == 0x0db8
     end
 
     test "handles unknown address family" do
@@ -977,14 +1403,62 @@ defmodule DNSpacketTest do
         %{
           type: :opt,
           rdata: [
-            %{code: :edns_client_subnet, family: 99, source: 16, scope: 0, 
+            %{code: :edns_client_subnet, family: 99, source: 16, scope: 0,
               addr: <<1, 2, 3, 4>>}
           ]
         }
       ]
-      
+
       result = DNSpacket.parse_edns_info(additional)
       assert result.options.ecs.client_subnet == <<1, 2, 3, 4>>
+    end
+
+    test "handles negative prefix length" do
+      # Test with negative prefix length
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :edns_client_subnet, family: 1, source: -1, scope: 0, addr: <<192, 168, 1, 1>>}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      # Should zero out the address
+      assert result.options.ecs.client_subnet == {0, 0, 0, 0}
+    end
+
+    test "handles prefix length equal to max bits" do
+      # Test IPv4 with prefix length 32
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :edns_client_subnet, family: 1, source: 32, scope: 0, addr: <<192, 168, 1, 1>>}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      assert result.options.ecs.client_subnet == {192, 168, 1, 1}
+    end
+
+    test "handles unknown tuple size in prefix mask" do
+      # This is a bit tricky to test since we need an unusual tuple size
+      # We'll test through the parse_ecs_address path with unknown family
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :edns_client_subnet, family: 99, source: 0, scope: 0, addr: <<192, 168>>}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      # Unknown family returns the raw binary
+      assert result.options.ecs.client_subnet == <<192, 168>>
     end
   end
 
@@ -1018,14 +1492,14 @@ defmodule DNSpacketTest do
         0x80, 0x00,               # Flags (DNSSEC OK)
         0x00, 0x00                # RDLENGTH = 0 (no options)
       >>
-      
+
       parsed = DNSpacket.parse(packet_with_edns)
-      
+
       # Verify basic packet structure
       assert parsed.id == 0x1234
       assert length(parsed.answer) == 1
       assert length(parsed.additional) == 1
-      
+
       # Verify EDNS info is parsed
       assert parsed.edns_info != nil
       assert parsed.edns_info.payload_size == 1232
@@ -1054,9 +1528,9 @@ defmodule DNSpacketTest do
         0x00, 0x04,  # RDLENGTH = 4
         192, 168, 1, 1  # IP address
       >>
-      
+
       parsed = DNSpacket.parse(simple_packet)
-      
+
       assert parsed.id == 0x1234
       assert parsed.edns_info == nil
     end
@@ -1079,14 +1553,14 @@ defmodule DNSpacketTest do
           }
         }
       }
-      
+
       opt_record = DNSpacket.create_edns_info_record(edns_info)
-      
+
       assert opt_record.type == :opt
       assert opt_record.payload_size == 4096
       assert opt_record.dnssec == 1
       assert length(opt_record.rdata) == 1
-      
+
       ecs_option = hd(opt_record.rdata)
       assert ecs_option.code == :edns_client_subnet
       assert ecs_option.family == 1
@@ -1104,11 +1578,11 @@ defmodule DNSpacketTest do
           nsid: "server1"
         }
       }
-      
+
       opt_record = DNSpacket.create_edns_info_record(edns_info)
-      
+
       assert length(opt_record.rdata) == 3
-      
+
       # Verify each option is present
       codes = Enum.map(opt_record.rdata, & &1.code)
       assert :edns_client_subnet in codes
@@ -1118,9 +1592,9 @@ defmodule DNSpacketTest do
 
     test "creates empty OPT record when no options provided" do
       edns_info = %{payload_size: 512}
-      
+
       opt_record = DNSpacket.create_edns_info_record(edns_info)
-      
+
       assert opt_record.type == :opt
       assert opt_record.payload_size == 512
       assert opt_record.rdata == []
@@ -1134,7 +1608,7 @@ defmodule DNSpacketTest do
         qr: 1,
         rd: 1,
         question: [%{qname: "example.com.", qtype: :a, qclass: :in}],
-        answer: [%{name: "example.com.", type: :a, class: :in, ttl: 300, 
+        answer: [%{name: "example.com.", type: :a, class: :in, ttl: 300,
                    rdata: %{addr: {192, 168, 1, 1}}}],
         edns_info: %{
           payload_size: 4096,
@@ -1149,18 +1623,18 @@ defmodule DNSpacketTest do
           }
         }
       }
-      
+
       # Create binary from packet
       binary = DNSpacket.create(original_packet)
-      
+
       # Parse binary back to packet
       parsed_packet = DNSpacket.parse(binary)
-      
+
       # Verify basic structure
       assert parsed_packet.id == original_packet.id
       assert parsed_packet.qr == original_packet.qr
       assert length(parsed_packet.answer) == 1
-      
+
       # Verify EDNS info is preserved
       assert parsed_packet.edns_info != nil
       assert parsed_packet.edns_info.payload_size == 4096
@@ -1196,19 +1670,19 @@ defmodule DNSpacketTest do
           }
         }
       }
-      
+
       binary = DNSpacket.create(original_packet)
       parsed_packet = DNSpacket.parse(binary)
-      
+
       # Verify EDNS options are preserved
       edns = parsed_packet.edns_info
       assert edns.options.ecs.family == 2
       assert edns.options.ecs.client_subnet == {0x2001, 0xdb8, 0x1234, 0, 0, 0, 0, 0}
       assert edns.options.ecs.source_prefix == 48
-      
+
       assert edns.options.cookie.client == <<1, 2, 3, 4, 5, 6, 7, 8>>
       assert edns.options.cookie.server == <<9, 10, 11, 12, 13, 14, 15, 16>>
-      
+
       assert edns.options.nsid == "ns1.example.com"
     end
 
@@ -1220,10 +1694,10 @@ defmodule DNSpacketTest do
         question: [%{qname: "simple.example.com.", qtype: :a, qclass: :in}],
         edns_info: nil
       }
-      
+
       binary = DNSpacket.create(packet)
       parsed_packet = DNSpacket.parse(binary)
-      
+
       assert parsed_packet.edns_info == nil
       assert Enum.all?(parsed_packet.additional, &(&1.type != :opt))
     end
@@ -1235,7 +1709,7 @@ defmodule DNSpacketTest do
         rd: 1,
         question: [%{qname: "replace.example.com.", qtype: :a, qclass: :in}],
         additional: [
-          %{name: "ns1.example.com.", type: :a, class: :in, ttl: 300, 
+          %{name: "ns1.example.com.", type: :a, class: :in, ttl: 300,
             rdata: %{addr: {1, 2, 3, 4}}},
           %{type: :opt, payload_size: 512, ex_rcode: 0, version: 0, dnssec: 0, z: 0, rdata: []}
         ],
@@ -1247,18 +1721,18 @@ defmodule DNSpacketTest do
           }
         }
       }
-      
+
       binary = DNSpacket.create(packet)
       parsed_packet = DNSpacket.parse(binary)
-      
+
       # Should have exactly one OPT record with new settings
       opt_records = Enum.filter(parsed_packet.additional, &(&1.type == :opt))
       assert length(opt_records) == 1
-      
+
       assert parsed_packet.edns_info.payload_size == 4096
       assert parsed_packet.edns_info.dnssec == 1
       assert parsed_packet.edns_info.options.nsid == "new-server"
-      
+
       # Non-OPT records should be preserved
       non_opt_records = Enum.reject(parsed_packet.additional, &(&1.type == :opt))
       assert length(non_opt_records) == 1
@@ -1274,29 +1748,29 @@ defmodule DNSpacketTest do
           ecs: %{family: 1, client_subnet: {10, 0, 0, 0}, source_prefix: 8, scope_prefix: 0}
         }
       }
-      
+
       opt_record = DNSpacket.create_edns_info_record(edns_info)
       ecs_option = hd(opt_record.rdata)
       assert ecs_option.addr == <<10>>
-      
+
       # Test /16 prefix (2 bytes)
       edns_info2 = %{
         options: %{
           ecs: %{family: 1, client_subnet: {192, 168, 0, 0}, source_prefix: 16, scope_prefix: 0}
         }
       }
-      
+
       opt_record2 = DNSpacket.create_edns_info_record(edns_info2)
       ecs_option2 = hd(opt_record2.rdata)
       assert ecs_option2.addr == <<192, 168>>
-      
+
       # Test /24 prefix (3 bytes)
       edns_info3 = %{
         options: %{
           ecs: %{family: 1, client_subnet: {203, 0, 113, 0}, source_prefix: 24, scope_prefix: 0}
         }
       }
-      
+
       opt_record3 = DNSpacket.create_edns_info_record(edns_info3)
       ecs_option3 = hd(opt_record3.rdata)
       assert ecs_option3.addr == <<203, 0, 113>>
@@ -1309,21 +1783,648 @@ defmodule DNSpacketTest do
           ecs: %{family: 2, client_subnet: {0x2001, 0xdb8, 0, 0, 0, 0, 0, 0}, source_prefix: 32, scope_prefix: 0}
         }
       }
-      
+
       opt_record = DNSpacket.create_edns_info_record(edns_info)
       ecs_option = hd(opt_record.rdata)
       assert ecs_option.addr == <<0x20, 0x01, 0x0d, 0xb8>>
-      
+
       # Test /48 prefix (6 bytes)
       edns_info2 = %{
         options: %{
           ecs: %{family: 2, client_subnet: {0x2001, 0xdb8, 0x1234, 0, 0, 0, 0, 0}, source_prefix: 48, scope_prefix: 0}
         }
       }
-      
+
       opt_record2 = DNSpacket.create_edns_info_record(edns_info2)
       ecs_option2 = hd(opt_record2.rdata)
       assert ecs_option2.addr == <<0x20, 0x01, 0x0d, 0xb8, 0x12, 0x34>>
+    end
+
+    test "unknown address family with binary address" do
+      # Test unknown family (not 1 or 2)
+      edns_info = %{
+        options: %{
+          ecs: %{family: 99, client_subnet: <<1, 2, 3, 4>>, source_prefix: 32, scope_prefix: 0}
+        }
+      }
+
+      opt_record = DNSpacket.create_edns_info_record(edns_info)
+      ecs_option = hd(opt_record.rdata)
+      assert ecs_option.addr == <<1, 2, 3, 4>>
+    end
+  end
+
+  describe "New EDNS options parsing" do
+    test "parses DAU option" do
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :dau, algorithms: [7, 8, 10]}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      assert result.options.dau.algorithms == [7, 8, 10]
+    end
+
+    test "parses DHU option" do
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :dhu, algorithms: [1, 2]}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      assert result.options.dhu.algorithms == [1, 2]
+    end
+
+    test "parses N3U option" do
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :n3u, algorithms: [1]}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      assert result.options.n3u.algorithms == [1]
+    end
+
+    test "parses EDNS expire option with value" do
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :edns_expire, expire: 3600}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      assert result.options.edns_expire.expire == 3600
+    end
+
+    test "parses EDNS expire option without value" do
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :edns_expire, expire: nil}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      assert result.options.edns_expire.expire == nil
+    end
+
+    test "parses chain option" do
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :chain, closest_encloser: "example.com"}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      assert result.options.chain.closest_encloser == "example.com"
+    end
+
+    test "parses EDNS key tag option" do
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :edns_key_tag, key_tags: [12_345, 54_321]}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      assert result.options.edns_key_tag.key_tags == [12_345, 54_321]
+    end
+
+    test "parses EDNS client tag option" do
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :edns_client_tag, tag: 1234}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      assert result.options.edns_client_tag.tag == 1234
+    end
+
+    test "parses EDNS server tag option" do
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :edns_server_tag, tag: 5678}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      assert result.options.edns_server_tag.tag == 5678
+    end
+
+    test "parses report channel option" do
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :report_channel, agent_domain: "agent.example.com"}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      assert result.options.report_channel.agent_domain == "agent.example.com"
+    end
+
+    test "parses zoneversion option" do
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :zoneversion, version: 1_234_567_890_123_456}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      assert result.options.zoneversion.version == 1_234_567_890_123_456
+    end
+
+    test "parses update lease option" do
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :update_lease, lease: 7200}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      assert result.options.update_lease.lease == 7200
+    end
+
+    test "parses LLQ option" do
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :llq, version: 1, llq_opcode: 1, error_code: 0, llq_id: 1_234_567_890_123_456, lease_life: 3600}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      assert result.options.llq.version == 1
+      assert result.options.llq.llq_opcode == 1
+      assert result.options.llq.error_code == 0
+      assert result.options.llq.llq_id == 1_234_567_890_123_456
+      assert result.options.llq.lease_life == 3600
+    end
+
+    test "parses Umbrella ident option" do
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :umbrella_ident, ident: 0x12345678}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      assert result.options.umbrella_ident.ident == 0x12345678
+    end
+
+    test "parses DeviceID option" do
+      additional = [
+        %{
+          type: :opt,
+          rdata: [
+            %{code: :deviceid, device_id: "device123"}
+          ]
+        }
+      ]
+
+      result = DNSpacket.parse_edns_info(additional)
+      assert result.options.deviceid.device_id == "device123"
+    end
+  end
+
+  describe "New EDNS options creation" do
+    test "creates OPT record with DAU option" do
+      edns_info = %{
+        payload_size: 1232,
+        options: %{
+          dau: %{algorithms: [7, 8, 10]}
+        }
+      }
+
+      opt_record = DNSpacket.create_edns_info_record(edns_info)
+      assert length(opt_record.rdata) == 1
+
+      dau_option = hd(opt_record.rdata)
+      assert dau_option.code == :dau
+      assert dau_option.algorithms == [7, 8, 10]
+    end
+
+    test "creates OPT record with EDNS expire option" do
+      edns_info = %{
+        options: %{
+          edns_expire: %{expire: 3600}
+        }
+      }
+
+      opt_record = DNSpacket.create_edns_info_record(edns_info)
+      expire_option = hd(opt_record.rdata)
+      assert expire_option.code == :edns_expire
+      assert expire_option.expire == 3600
+    end
+
+    test "creates OPT record with key tag option" do
+      edns_info = %{
+        options: %{
+          edns_key_tag: %{key_tags: [12_345, 54_321]}
+        }
+      }
+
+      opt_record = DNSpacket.create_edns_info_record(edns_info)
+      key_tag_option = hd(opt_record.rdata)
+      assert key_tag_option.code == :edns_key_tag
+      assert key_tag_option.key_tags == [12_345, 54_321]
+    end
+
+    test "roundtrip test with new EDNS options" do
+      original_packet = %DNSpacket{
+        id: 0x1234,
+        qr: 0,
+        rd: 1,
+        question: [%{qname: "test.example.com.", qtype: :a, qclass: :in}],
+        edns_info: %{
+          payload_size: 4096,
+          dnssec: 1,
+          options: %{
+            dau: %{algorithms: [7, 8]},
+            edns_expire: %{expire: 3600},
+            edns_key_tag: %{key_tags: [12_345]},
+            zoneversion: %{version: 123_456_789}
+          }
+        }
+      }
+
+      binary = DNSpacket.create(original_packet)
+      parsed_packet = DNSpacket.parse(binary)
+
+      # Verify EDNS options are preserved
+      edns = parsed_packet.edns_info
+      assert edns.options.dau.algorithms == [7, 8]
+      assert edns.options.edns_expire.expire == 3600
+      assert edns.options.edns_key_tag.key_tags == [12_345]
+      assert edns.options.zoneversion.version == 123_456_789
+    end
+
+    test "create_cookie_option coverage" do
+      # Test cookie with client only
+      edns_info1 = %{
+        options: %{
+          cookie: %{client: <<1, 2, 3, 4, 5, 6, 7, 8>>, server: nil}
+        }
+      }
+
+      opt_record1 = DNSpacket.create_edns_info_record(edns_info1)
+      cookie_opt1 = hd(opt_record1.rdata)
+      assert cookie_opt1.cookie == <<1, 2, 3, 4, 5, 6, 7, 8>>
+
+      # Test cookie with client and server
+      edns_info2 = %{
+        options: %{
+          cookie: %{client: <<1, 2, 3, 4, 5, 6, 7, 8>>, server: <<9, 10, 11, 12, 13, 14, 15, 16>>}
+        }
+      }
+
+      opt_record2 = DNSpacket.create_edns_info_record(edns_info2)
+      cookie_opt2 = hd(opt_record2.rdata)
+      assert cookie_opt2.cookie == <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16>>
+    end
+  end
+
+  describe "create_edns_options/1" do
+    test "creates empty binary for nil input" do
+      assert DNSpacket.create_edns_options(nil) == <<>>
+    end
+
+    test "creates empty binary for non-map input" do
+      assert DNSpacket.create_edns_options("invalid") == <<>>
+      assert DNSpacket.create_edns_options([]) == <<>>
+    end
+
+    test "creates binary from options map" do
+      options = %{
+        ecs: %{family: 1, client_subnet: {10, 0, 0, 0}, source_prefix: 8, scope_prefix: 0}
+      }
+
+      result = DNSpacket.create_edns_options(options)
+
+      # Should create ECS option binary
+      assert byte_size(result) > 0
+      # Verify it starts with ECS option code (8)
+      <<8::16, _rest::binary>> = result
+    end
+
+    test "ignores invalid option keys" do
+      options = %{
+        invalid_key: %{some: "data"},
+        ecs: %{family: 1, client_subnet: {10, 0, 0, 0}, source_prefix: 8, scope_prefix: 0}
+      }
+
+      result = DNSpacket.create_edns_options(options)
+
+      # Should only create ECS option, ignoring invalid_key
+      <<8::16, length::16, _data::binary-size(length)>> = result
+    end
+
+    test "creates all supported EDNS options" do
+      options = %{
+        ecs: %{family: 1, client_subnet: {192, 168, 1, 0}, source_prefix: 24, scope_prefix: 0},
+        cookie: %{client: <<1, 2, 3, 4, 5, 6, 7, 8>>, server: <<9, 10, 11, 12, 13, 14, 15, 16>>},
+        nsid: "server1.example.com",
+        extended_dns_error: %{info_code: 18, extra_text: "Blocked"},
+        tcp_keepalive: %{timeout: 300},
+        padding: %{length: 16},
+        dau: %{algorithms: [7, 8, 10]},
+        dhu: %{algorithms: [1, 2]},
+        n3u: %{algorithms: [1]},
+        edns_expire: %{expire: 3600},
+        chain: %{closest_encloser: "example.com"},
+        edns_key_tag: %{key_tags: [12_345, 54_321]},
+        edns_client_tag: %{tag: 1234},
+        edns_server_tag: %{tag: 5678},
+        report_channel: %{agent_domain: "agent.example.com"},
+        zoneversion: %{version: 1_234_567_890_123_456},
+        update_lease: %{lease: 7200},
+        llq: %{version: 1, llq_opcode: 1, error_code: 0, llq_id: 1_234_567_890_123_456, lease_life: 3600},
+        umbrella_ident: %{ident: 0x12345678},
+        deviceid: %{device_id: "device123"},
+        unknown: [%{code: 65_535, data: <<1, 2, 3, 4>>}]
+      }
+
+      result = DNSpacket.create_edns_options(options)
+
+      # Verify result is non-empty binary
+      assert byte_size(result) > 0
+
+      # Parse the result to verify all options are present
+      parsed_options = DNSpacket.parse_opt_rr([], result)
+      assert length(parsed_options) >= 20  # At least 20 options
+
+      # Verify a few specific options
+      assert Enum.any?(parsed_options, &(&1.code == :edns_client_subnet))
+      assert Enum.any?(parsed_options, &(&1.code == :cookie))
+      assert Enum.any?(parsed_options, &(&1.code == :nsid))
+      assert Enum.any?(parsed_options, &(&1.code == :dau))
+      assert Enum.any?(parsed_options, &(&1.code == :llq))
+    end
+
+    test "creates padding option with specific length" do
+      options = %{
+        padding: %{length: 32}
+      }
+
+      result = DNSpacket.create_edns_options(options)
+
+      # Should create padding option with 32 bytes of zeros
+      <<12::16, 32::16, padding_data::binary-size(32)>> = result
+      assert padding_data == <<0::size(32 * 8)>>
+    end
+
+    test "creates tcp_keepalive option without timeout" do
+      options = %{
+        tcp_keepalive: %{timeout: nil}
+      }
+
+      result = DNSpacket.create_edns_options(options)
+
+      # Should create empty tcp_keepalive option
+      <<11::16, 0::16>> = result
+    end
+
+    test "creates edns_expire option without value" do
+      options = %{
+        edns_expire: %{expire: nil}
+      }
+
+      result = DNSpacket.create_edns_options(options)
+
+      # Should create empty edns_expire option
+      <<9::16, 0::16>> = result
+    end
+
+    test "handles unknown options list" do
+      options = %{
+        unknown: [
+          %{code: 65_001, data: <<1, 2, 3>>},
+          %{code: 65_002, data: <<4, 5, 6, 7>>}
+        ]
+      }
+
+      result = DNSpacket.create_edns_options(options)
+
+      # Should create both unknown options
+      parsed = DNSpacket.parse_opt_rr([], result)
+      assert length(parsed) == 2
+      assert Enum.all?(parsed, &(&1.data in [<<1, 2, 3>>, <<4, 5, 6, 7>>]))
+    end
+  end
+
+  describe "merge_edns_info_to_additional" do
+    test "handles nil edns_info" do
+      packet = %DNSpacket{
+        id: 0x1234,
+        qr: 0,
+        rd: 1,
+        question: [%{qname: "test.com.", qtype: :a, qclass: :in}],
+        additional: [
+          %{name: "ns1.test.com.", type: :a, class: :in, ttl: 300,
+            rdata: %{addr: {1, 2, 3, 4}}}
+        ],
+        edns_info: nil
+      }
+
+      binary = DNSpacket.create(packet)
+      parsed = DNSpacket.parse(binary)
+
+      # Should preserve original additional records
+      assert length(parsed.additional) == 1
+      assert hd(parsed.additional).type == :a
+    end
+  end
+
+  describe "convert_option_to_rdata through create_edns_info_record" do
+    test "converts all option types to rdata" do
+      edns_info = %{
+        payload_size: 4096,
+        options: %{
+          ecs: %{family: 1, client_subnet: {192, 168, 1, 0}, source_prefix: 24, scope_prefix: 0},
+          cookie: %{client: <<1, 2, 3, 4, 5, 6, 7, 8>>, server: <<9, 10, 11, 12, 13, 14, 15, 16>>},
+          nsid: "server.example.com",
+          extended_dns_error: %{info_code: 18, extra_text: "Blocked by policy"},
+          tcp_keepalive: %{timeout: 300},
+          padding: %{length: 8},
+          dau: %{algorithms: [7, 8, 10]},
+          dhu: %{algorithms: [1, 2]},
+          n3u: %{algorithms: [1]},
+          edns_expire: %{expire: 3600},
+          chain: %{closest_encloser: "closest.example.com"},
+          edns_key_tag: %{key_tags: [12_345, 54_321]},
+          edns_client_tag: %{tag: 1234},
+          edns_server_tag: %{tag: 5678},
+          report_channel: %{agent_domain: "report.example.com"},
+          zoneversion: %{version: 1_234_567_890_123_456},
+          update_lease: %{lease: 7200},
+          llq: %{version: 1, llq_opcode: 1, error_code: 0, llq_id: 9_876_543_210, lease_life: 3600},
+          umbrella_ident: %{ident: 0x12345678},
+          deviceid: %{device_id: "test-device-001"},
+          unknown: [
+            %{code: 65_000, data: <<1, 2, 3>>},
+            %{code: 65_001, data: <<4, 5, 6, 7>>}
+          ]
+        }
+      }
+
+      opt_record = DNSpacket.create_edns_info_record(edns_info)
+
+      # Verify the OPT record structure
+      assert opt_record.type == :opt
+      assert opt_record.payload_size == 4096
+      assert is_list(opt_record.rdata)
+
+      # Count the rdata entries
+      assert length(opt_record.rdata) == 22  # 20 known options + 2 unknown
+
+      # Verify ECS conversion
+      ecs_rdata = Enum.find(opt_record.rdata, &(&1.code == :edns_client_subnet))
+      assert ecs_rdata.family == 1
+      assert ecs_rdata.source == 24
+      assert ecs_rdata.scope == 0
+      assert ecs_rdata.addr == <<192, 168, 1>>
+
+      # Verify cookie conversion
+      cookie_rdata = Enum.find(opt_record.rdata, &(&1.code == :cookie))
+      assert cookie_rdata.cookie == <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16>>
+
+      # Verify NSID conversion
+      nsid_rdata = Enum.find(opt_record.rdata, &(&1.code == :nsid))
+      assert nsid_rdata.data == "server.example.com"
+
+      # Verify extended DNS error conversion
+      ede_rdata = Enum.find(opt_record.rdata, &(&1.code == :extended_dns_error))
+      assert ede_rdata.info_code == 18
+      assert ede_rdata.txt == "Blocked by policy"
+
+      # Verify TCP keepalive conversion
+      tcp_rdata = Enum.find(opt_record.rdata, &(&1.code == :edns_tcp_keepalive))
+      assert tcp_rdata.data == <<300::16>>
+
+      # Verify padding conversion
+      padding_rdata = Enum.find(opt_record.rdata, &(&1.code == :padding))
+      assert padding_rdata.data == <<0, 0, 0, 0, 0, 0, 0, 0>>
+
+      # Verify algorithm options
+      dau_rdata = Enum.find(opt_record.rdata, &(&1.code == :dau))
+      assert dau_rdata.algorithms == [7, 8, 10]
+
+      # Verify LLQ conversion
+      llq_rdata = Enum.find(opt_record.rdata, &(&1.code == :llq))
+      assert llq_rdata.version == 1
+      assert llq_rdata.llq_id == 9_876_543_210
+
+      # Verify unknown options are passed through
+      unknown_rdatas = Enum.filter(opt_record.rdata, &(&1.code in [65_000, 65_001]))
+      assert length(unknown_rdatas) == 2
+    end
+
+    test "converts tcp_keepalive with nil timeout" do
+      edns_info = %{
+        options: %{
+          tcp_keepalive: %{timeout: nil}
+        }
+      }
+
+      opt_record = DNSpacket.create_edns_info_record(edns_info)
+      tcp_rdata = hd(opt_record.rdata)
+
+      assert tcp_rdata.code == :edns_tcp_keepalive
+      assert tcp_rdata.data == <<>>
+    end
+
+    test "converts cookie with server nil" do
+      edns_info = %{
+        options: %{
+          cookie: %{client: <<1, 2, 3, 4, 5, 6, 7, 8>>, server: nil}
+        }
+      }
+
+      opt_record = DNSpacket.create_edns_info_record(edns_info)
+      cookie_rdata = hd(opt_record.rdata)
+
+      assert cookie_rdata.code == :cookie
+      assert cookie_rdata.cookie == <<1, 2, 3, 4, 5, 6, 7, 8>>
+    end
+
+    test "handles invalid option gracefully" do
+      edns_info = %{
+        options: %{
+          invalid_option: %{some: "data"}
+        }
+      }
+
+      opt_record = DNSpacket.create_edns_info_record(edns_info)
+
+      # Should return empty rdata list for invalid options
+      assert opt_record.rdata == []
+    end
+
+    test "converts ECS with different address families" do
+      # Test IPv4
+      edns_info_v4 = %{
+        options: %{
+          ecs: %{family: 1, client_subnet: {10, 0, 0, 0}, source_prefix: 8, scope_prefix: 0}
+        }
+      }
+
+      opt_record_v4 = DNSpacket.create_edns_info_record(edns_info_v4)
+      ecs_v4 = hd(opt_record_v4.rdata)
+      assert ecs_v4.addr == <<10>>
+
+      # Test IPv6
+      edns_info_v6 = %{
+        options: %{
+          ecs: %{family: 2, client_subnet: {0x2001, 0xdb8, 0, 0, 0, 0, 0, 1}, source_prefix: 64, scope_prefix: 0}
+        }
+      }
+
+      opt_record_v6 = DNSpacket.create_edns_info_record(edns_info_v6)
+      ecs_v6 = hd(opt_record_v6.rdata)
+      assert ecs_v6.addr == <<0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0>>
     end
   end
 end

--- a/test/dns_test.exs
+++ b/test/dns_test.exs
@@ -95,10 +95,12 @@ defmodule DNSTest do
 
   describe "option functions" do
     test "option/1 returns correct atom for valid option codes" do
-      assert DNS.option(0) == :reserved0
+      assert DNS.option(0) == :reserved
       assert DNS.option(8) == :edns_client_subnet
       assert DNS.option(10) == :cookie
       assert DNS.option(15) == :extended_dns_error
+      assert DNS.option(18) == :report_channel
+      assert DNS.option(19) == :zoneversion
     end
 
     test "option/1 returns nil for invalid option codes" do
@@ -106,10 +108,14 @@ defmodule DNSTest do
     end
 
     test "option_code/1 returns correct code for valid atoms" do
-      assert DNS.option_code(:reserved0) == 0
+      assert DNS.option_code(:reserved) == 0
+      assert DNS.option_code(:update_lease) == 2
       assert DNS.option_code(:edns_client_subnet) == 8
       assert DNS.option_code(:cookie) == 10
       assert DNS.option_code(:extended_dns_error) == 15
+      assert DNS.option_code(:report_channel) == 18
+      assert DNS.option_code(:zoneversion) == 19
+      assert DNS.option_code(:umbrella_ident) == 20_292
     end
 
     test "option_code/1 returns nil for invalid atoms" do
@@ -134,7 +140,7 @@ defmodule DNSTest do
   describe "rcode_text/0" do
     test "returns map with human-readable rcode descriptions" do
       rcode_text = DNS.rcode_text()
-      
+
       assert is_map(rcode_text)
       assert rcode_text[:noerror] == "No Error"
       assert rcode_text[:formerr] == "Format Error"

--- a/test/tenbin_dns_test.exs
+++ b/test/tenbin_dns_test.exs
@@ -106,7 +106,7 @@ defmodule TenbinDnsTest do
     test "parse handles malformed packets gracefully" do
       # Test with insufficient data
       short_packet = <<0x18, 0x25>>
-      
+
       assert_raise FunctionClauseError, fn ->
         DNSpacket.parse(short_packet)
       end
@@ -122,7 +122,7 @@ defmodule TenbinDnsTest do
         0x00, 0x00,  # NSCOUNT = 0
         0x00, 0x00   # ARCOUNT = 0
       >>
-      
+
       parsed = DNSpacket.parse(empty_question_packet)
       assert parsed.id == 0x1825
       assert parsed.question == []
@@ -134,7 +134,7 @@ defmodule TenbinDnsTest do
         id: 0x1234,
         question: [%{qname: "test.com.", qtype: :invalid_type, qclass: :in}]
       }
-      
+
       # Should not crash, even with invalid type
       assert_raise ArgumentError, fn ->
         DNSpacket.create(packet)
@@ -145,7 +145,7 @@ defmodule TenbinDnsTest do
       # Test with maximum length domain name
       long_label = String.duplicate("a", 63)
       long_domain = "#{long_label}.com"
-      
+
       result = DNSpacket.create_domain_name(long_domain)
       assert is_binary(result)
       assert byte_size(result) > 0
@@ -161,7 +161,7 @@ defmodule TenbinDnsTest do
         z: 0,
         rdata: []
       }
-      
+
       result = DNSpacket.create_rr(opt_record)
       assert is_binary(result)
       # Should have minimal OPT record structure
@@ -174,7 +174,7 @@ defmodule TenbinDnsTest do
       # Test with 255-byte string (maximum for DNS)
       max_string = String.duplicate("x", 255)
       result = DNSpacket.create_character_string(max_string)
-      
+
       assert byte_size(result) == 256  # 1 byte length + 255 bytes data
       assert binary_part(result, 0, 1) == <<255>>
     end
@@ -182,7 +182,7 @@ defmodule TenbinDnsTest do
     test "rdata parsing with insufficient data" do
       # Test A record with insufficient rdata
       insufficient_a_rdata = <<192, 168>>  # Only 2 bytes instead of 4
-      
+
       # This should return the default fallback instead of raising
       result = DNSpacket.parse_rdata(insufficient_a_rdata, :a, :in, <<>>)
       assert result == %{type: :a, class: :in, rdata: <<192, 168>>}
@@ -200,7 +200,7 @@ defmodule TenbinDnsTest do
       assert DNS.type(28) == :aaaa
       assert DNS.type(41) == :opt  # This line was not covered
       assert DNS.type(255) == :any
-      
+
       # Test fallback to Map.get for non-optimized types
       assert DNS.type(6) == :soa
       assert DNS.type(999) == nil  # Non-existent type
@@ -216,7 +216,7 @@ defmodule TenbinDnsTest do
       assert DNS.type_code(:aaaa) == 28
       assert DNS.type_code(:opt) == 41
       assert DNS.type_code(:any) == 255
-      
+
       # Test fallback to Map.get for non-optimized types
       assert DNS.type_code(:soa) == 6
       assert DNS.type_code(:invalid) == nil  # Non-existent type
@@ -226,7 +226,7 @@ defmodule TenbinDnsTest do
       # Test the optimized pattern matching clauses
       assert DNS.class(1) == :in
       assert DNS.class(255) == :any
-      
+
       # Test fallback to Map.get for non-optimized classes
       assert DNS.class(2) == :cs
       assert DNS.class(999) == nil  # Non-existent class
@@ -236,7 +236,7 @@ defmodule TenbinDnsTest do
       # Test the optimized pattern matching clauses
       assert DNS.class_code(:in) == 1
       assert DNS.class_code(:any) == 255
-      
+
       # Test fallback to Map.get for non-optimized classes
       assert DNS.class_code(:cs) == 2
       assert DNS.class_code(:invalid) == nil  # Non-existent class


### PR DESCRIPTION
## Summary
- Implement structured EDNS additional section parsing (fixes #19)
- Improve test coverage from 67.62% to 98.71%
- Add complete EDNS0 support with all IANA-registered option codes

## Changes

### EDNS Parsing and Creation
- Add `edns_info` field to DNSpacket struct for structured EDNS data
- Implement `parse_edns_info/1` to parse EDNS options from additional section
- Implement `create_edns_info_record/1` for creating OPT records from structured data
- Support all 21 IANA-registered EDNS option types

### EDNS Options Supported
- ECS (EDNS Client Subnet)
- DNS Cookies
- NSID (Name Server Identifier)
- Extended DNS Errors
- TCP Keepalive
- Padding
- DAU/DHU/N3U (DNSSEC Algorithm Understanding)
- EDNS Expire
- Chain Query
- EDNS Key Tag
- EDNS Client/Server Tag
- Report Channel
- Zone Version
- Update Lease
- LLQ (Long-Lived Queries)
- Umbrella Ident
- DeviceID

🤖 Generated with [Claude Code](https://claude.ai/code)