### PR TITLE
Fix formatting for Elixir 1.19.3 compatibility

### DIFF
--- a/lib/dns_packet.ex
+++ b/lib/dns_packet.ex
@@ -317,8 +317,7 @@ defmodule DNSpacket do
       end
 
     <<0, DNS.type_code(:opt)::16, rr.payload_size::16, rr.ex_rcode::8, rr.version::8,
-      rr.dnssec::1,
-      rr.z::15>> <>
+      rr.dnssec::1, rr.z::15>> <>
       add_rdlength(rdata_binary)
   end
 
@@ -1057,8 +1056,7 @@ defmodule DNSpacket do
   @doc false
   def create_rdata(rdata, :rrsig, _) do
     <<rdata.type_covered::16, rdata.algorithm::8, rdata.labels::8, rdata.original_ttl::32,
-      rdata.signature_expiration::32, rdata.signature_inception::32,
-      rdata.key_tag::16>> <>
+      rdata.signature_expiration::32, rdata.signature_inception::32, rdata.key_tag::16>> <>
       create_domain_name(rdata.signer_name) <>
       <<rdata.signature::binary>>
   end


### PR DESCRIPTION
## Summary

Fixes CI failures caused by Elixir 1.19.3 formatter having stricter rules than 1.17.3.

## Problem

After upgrading CI to use Elixir 1.19.3 (#54), the Code Quality and Test jobs failed with formatting errors in \`lib/dns_packet.ex\`.

Elixir 1.19.3's formatter consolidates binary pattern parts more aggressively than 1.17.3, causing \`mix format --check-formatted\` to fail.

## Changes

Updated \`lib/dns_packet.ex\` to comply with Elixir 1.19.3 formatter rules:

### Line 320-321 (OPT record creation)
**Before:**
\`\`\`elixir
<<0, DNS.type_code(:opt)::16, rr.payload_size::16, rr.ex_rcode::8, rr.version::8,
  rr.dnssec::1,
  rr.z::15>> <>
\`\`\`

**After:**
\`\`\`elixir
<<0, DNS.type_code(:opt)::16, rr.payload_size::16, rr.ex_rcode::8, rr.version::8,
  rr.dnssec::1, rr.z::15>> <>
\`\`\`

### Line 1059-1060 (RRSIG record creation)
**Before:**
\`\`\`elixir
<<rdata.type_covered::16, rdata.algorithm::8, rdata.labels::8, rdata.original_ttl::32,
  rdata.signature_expiration::32, rdata.signature_inception::32,
  rdata.key_tag::16>> <>
\`\`\`

**After:**
\`\`\`elixir
<<rdata.type_covered::16, rdata.algorithm::8, rdata.labels::8, rdata.original_ttl::32,
  rdata.signature_expiration::32, rdata.signature_inception::32, rdata.key_tag::16>> <>
\`\`\`

## Testing

- Ran \`mix format\` locally with Elixir 1.19.3
- Verified changes are formatting-only (no logic changes)
- CI will validate against both Elixir 1.17.3 and 1.19.3

## Related Issues

- Fixes CI failures from #54
- Related to #55 (lefthook workaround needed for commit)