### PR TITLE
docs(readme): add a Quick Start section with a verified round-trip

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,39 @@
 
 An Elixir library for DNS packet parsing and creation. Tenbin.DNS provides handling of DNS protocol operations with support for 19+ DNS record types, DNSSEC, web optimization features, and EDNS0 extensions.
 
+## Quick Start
+
+```elixir
+# 1. Add the dependency in mix.exs
+def deps do
+  [{:tenbin_dns, "~> 0.7.0"}]
+end
+```
+
+```elixir
+# 2. Build a DNS query packet and serialize it to wire format
+iex> packet = %DNSpacket{
+...>   id: 0x1234,
+...>   rd: 1,
+...>   question: [%{qname: "example.com.", qtype: :a, qclass: :in}]
+...> }
+iex> binary = DNSpacket.create(packet)
+iex> byte_size(binary)
+29
+```
+
+```elixir
+# 3. Parse a wire-format DNS packet back into a struct
+#    (parse/1 returns %DNSpacket{} directly — no {:ok, _} wrap)
+iex> parsed = DNSpacket.parse(binary)
+iex> parsed.id
+4660
+iex> hd(parsed.question)
+%{qname: "example.com.", qtype: :a, qclass: :in}
+```
+
+See [Usage](#usage) below for richer record types (HTTPS / SVCB, SRV, DNSSEC) and EDNS0 examples.
+
 ## Features
 
 - **DNS packet parsing and creation** - Binary pattern matching with compile-time optimizations

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An Elixir library for DNS packet parsing and creation. Tenbin.DNS provides handl
 defp deps do
   [
     # ...
-    {:tenbin_dns, "~> 0.7.0"}
+    {:tenbin_dns, "~> 0.7.1"}
   ]
 end
 ```
@@ -65,7 +65,7 @@ Add `tenbin_dns` to your list of dependencies in `mix.exs`:
 defp deps do
   [
     # ... existing dependencies
-    {:tenbin_dns, "~> 0.7.0"}
+    {:tenbin_dns, "~> 0.7.1"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -5,14 +5,19 @@ An Elixir library for DNS packet parsing and creation. Tenbin.DNS provides handl
 ## Quick Start
 
 ```elixir
-# 1. Add the dependency in mix.exs
-def deps do
-  [{:tenbin_dns, "~> 0.7.0"}]
+# 1. Add the entry to your mix.exs deps list
+defp deps do
+  [
+    # ...
+    {:tenbin_dns, "~> 0.7.0"}
+  ]
 end
 ```
 
 ```elixir
-# 2. Build a DNS query packet and serialize it to wire format
+# 2. Build a DNS query packet and serialize it to wire format.
+#    Note: qname must be an FQDN with a trailing dot ("example.com.")
+#    so the wire packet ends in the DNS root label.
 iex> packet = %DNSpacket{
 ...>   id: 0x1234,
 ...>   rd: 1,
@@ -57,8 +62,9 @@ See [Usage](#usage) below for richer record types (HTTPS / SVCB, SRV, DNSSEC) an
 Add `tenbin_dns` to your list of dependencies in `mix.exs`:
 
 ```elixir
-def deps do
+defp deps do
   [
+    # ... existing dependencies
     {:tenbin_dns, "~> 0.7.0"}
   ]
 end
@@ -74,7 +80,7 @@ packet = %DNSpacket{
   id: 12345,
   rd: 1,
   question: [
-    %{qname: "example.com", qtype: :a, qclass: :in}
+    %{qname: "example.com.", qtype: :a, qclass: :in}
   ]
 }
 
@@ -89,10 +95,10 @@ binary_packet = DNSpacket.create(packet)
 https_packet = %DNSpacket{
   id: 12346,
   qr: 1,
-  question: [%{qname: "example.com", qtype: :https, qclass: :in}],
+  question: [%{qname: "example.com.", qtype: :https, qclass: :in}],
   answer: [%{
-    name: "example.com", 
-    type: :https, 
+    name: "example.com.",
+    type: :https,
     class: :in, 
     ttl: 300,
     rdata: %{
@@ -111,10 +117,10 @@ https_packet = %DNSpacket{
 srv_packet = %DNSpacket{
   id: 12347,
   qr: 1,
-  question: [%{qname: "_sip._tcp.example.com", qtype: :srv, qclass: :in}],
+  question: [%{qname: "_sip._tcp.example.com.", qtype: :srv, qclass: :in}],
   answer: [%{
-    name: "_sip._tcp.example.com", 
-    type: :srv, 
+    name: "_sip._tcp.example.com.",
+    type: :srv,
     class: :in, 
     ttl: 300,
     rdata: %{priority: 10, weight: 5, port: 5060, target: "sip.example.com"}
@@ -126,8 +132,8 @@ dnskey_packet = %DNSpacket{
   id: 12348,
   qr: 1,
   answer: [%{
-    name: "example.com", 
-    type: :dnskey, 
+    name: "example.com.",
+    type: :dnskey,
     class: :in, 
     ttl: 3600,
     rdata: %{flags: 257, protocol: 3, algorithm: 8, public_key: <<0x03, 0x01, 0x00, 0x01>>}

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ srv_packet = %DNSpacket{
     type: :srv,
     class: :in, 
     ttl: 300,
-    rdata: %{priority: 10, weight: 5, port: 5060, target: "sip.example.com"}
+    rdata: %{priority: 10, weight: 5, port: 5060, target: "sip.example.com."}
   }]
 }
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ end
 ```elixir
 # 2. Build a DNS query packet and serialize it to wire format.
 #    Note: qname must be an FQDN with a trailing dot ("example.com.")
-#    so the wire packet ends in the DNS root label.
+#    so the encoded name ends in the DNS root label (a zero-length
+#    label terminator).
 iex> packet = %DNSpacket{
 ...>   id: 0x1234,
 ...>   rd: 1,
@@ -99,11 +100,11 @@ https_packet = %DNSpacket{
   answer: [%{
     name: "example.com.",
     type: :https,
-    class: :in, 
+    class: :in,
     ttl: 300,
     rdata: %{
-      priority: 1, 
-      target: ".", 
+      priority: 1,
+      target: ".",
       svc_params: %{
         alpn: ["h3", "h2"],                           # HTTP/3, HTTP/2 support
         ipv4_hints: [{104, 16, 132, 229}],           # IPv4 optimization hints
@@ -121,7 +122,7 @@ srv_packet = %DNSpacket{
   answer: [%{
     name: "_sip._tcp.example.com.",
     type: :srv,
-    class: :in, 
+    class: :in,
     ttl: 300,
     rdata: %{priority: 10, weight: 5, port: 5060, target: "sip.example.com."}
   }]
@@ -134,7 +135,7 @@ dnskey_packet = %DNSpacket{
   answer: [%{
     name: "example.com.",
     type: :dnskey,
-    class: :in, 
+    class: :in,
     ttl: 3600,
     rdata: %{flags: 257, protocol: 3, algorithm: 8, public_key: <<0x03, 0x01, 0x00, 0x01>>}
   }]
@@ -230,7 +231,7 @@ LEFTHOOK=0 git commit -m "Emergency fix"
 
 Tenbin.DNS includes optimizations for DNS operations:
 - **Compile-time optimization** with native compilation
-- **Function inlining** for speed-critical paths  
+- **Function inlining** for speed-critical paths
 - **Binary pattern matching** for protocol handling
 - **O(1) constant lookups** using compile-time generated maps
 - **EDNS hybrid structure** providing 35-69% faster access to common options


### PR DESCRIPTION
## Summary

ecosystem CLAUDE.md TODO #3「各リポジトリ README に Quick Start を統一導入」の一環。タグライン直後に独立した Quick Start セクションを追加します。

## 変更内容

### Quick Start セクション新設

3 ステップで「触ってみる」を完結:

1. `mix.exs` に `{:tenbin_dns, "~> 0.7.0"}` 追加（既存 Installation セクションと整合）
2. `%DNSpacket{}` 構造体でクエリを構築 → `DNSpacket.create/1` でワイヤフォーマットへ
3. `DNSpacket.parse/1` でワイヤフォーマットを構造体に戻し、フィールドを参照

### Issue 起票時のサンプル誤りの修正

Issue #85 本文では以下の例を提示していました:

```elixir
iex> {:ok, parsed} = DNSpacket.parse(binary)
```

しかし実装を確認したところ `DNSpacket.parse/1` は `%DNSpacket{}` を直接返す（`{:ok, ...}` ラップなし）ことが判明（`lib/dns_packet.ex:1354` と round-trip test より）。本 PR では実装に合わせて修正:

```elixir
iex> parsed = DNSpacket.parse(binary)
```

### 出力値の事実検証

iex 出力 3 件（`byte_size/1`, `parsed.id`, `hd(parsed.question)`) は本 PR ブランチで実際に `mix run` を回して得た値を記載しています。読者がコピペして手元で実行したときに README の表示と一致します。

| iex 例 | 実出力 |
|---|---|
| `byte_size(binary)` | `29` |
| `parsed.id` | `4660` |
| `hd(parsed.question)` | `%{qname: "example.com.", qtype: :a, qclass: :in}` |

## Test plan
- [x] `mix test` 199 tests / 1 doctest / 0 failures
- [x] `mix credo --strict` 0 issues
- [x] `mix format --check-formatted` 通過
- [x] Quick Start のコードを `mix run` で実走、READMEに記載した出力と一致

## 関連
- ecosystem CLAUDE.md TODO #3
- 参考: [tdig README](https://github.com/smkwlab/tdig/blob/main/README.md) のフォーマットを踏襲
- 同 TODO の対応事例: [smkwlab/elixir_dnstap#29](https://github.com/smkwlab/elixir_dnstap/pull/29)（先行 merged、Copilot レビュー 4 ラウンドの教訓を反映済み）

resolve #85