### PR TITLE
Use shared Renovate preset from smkwlab/.github

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,21 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "enabledManagers": ["mix"],
-  "schedule": ["before 6am on monday"],
-  "timezone": "Asia/Tokyo",
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["before 6am on monday"]
-  },
-  "packageRules": [
-    {
-      "matchManagers": ["mix"],
-      "matchDatasources": ["hex"],
-      "matchUpdateTypes": ["minor", "patch", "digest", "lockFileMaintenance"],
-      "groupName": "elixir dependencies",
-      "automerge": true,
-      "platformAutomerge": true
-    }
-  ]
+  "extends": ["github>smkwlab/.github:elixir#v1"]
 }


### PR DESCRIPTION
## Summary

Replace the duplicated Renovate configuration with a one-line `extends` of the org-wide shared **Elixir** preset, pinned to the `v1` tag.

```jsonc
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["github>smkwlab/.github:elixir#v1"]
}
```

The mix-manager config, `lockFileMaintenance`, grouping (`elixir dependencies`), and grouped minor/patch/digest auto-merge are now defined centrally in `smkwlab/.github` (`elixir.json` @ `v1`), so behavior is preserved.

## Context

Part of the ecosystem-wide Renovate consolidation. Shared presets added/pinned in smkwlab/.github#28 and #29 (merged, released as `v1.6.0`). The Elixir preset intentionally retains minor/lockFileMaintenance auto-merge as a documented exception to the org's patch/digest-only default.
