### PR TITLE
Fix: preserve wire order of records within each parsed section

### DIFF
--- a/lib/dns_packet.ex
+++ b/lib/dns_packet.ex
@@ -786,7 +786,9 @@ defmodule DNSpacket do
 
     # The section parsers accumulate by prepending; restore wire order here.
     # Record order is semantically meaningful in DNS (CNAME chains,
-    # round-robin), see issue #98.
+    # round-robin), see issue #98. additional is reversed before the EDNS
+    # lookup so that (invalid) multi-OPT packets resolve the same OPT record
+    # as the wire order implies.
     additional_in_order = :lists.reverse(additional)
 
     {:lists.reverse(question), :lists.reverse(answer), :lists.reverse(authority),

--- a/lib/dns_packet.ex
+++ b/lib/dns_packet.ex
@@ -784,7 +784,13 @@ defmodule DNSpacket do
     {rest3, authority} = parse_answer_fast(rest2, nscount, orig_body, [])
     {_, additional} = parse_answer_fast(rest3, arcount, orig_body, [])
 
-    {question, answer, authority, additional, parse_edns_info(additional)}
+    # The section parsers accumulate by prepending; restore wire order here.
+    # Record order is semantically meaningful in DNS (CNAME chains,
+    # round-robin), see issue #98.
+    additional_in_order = :lists.reverse(additional)
+
+    {:lists.reverse(question), :lists.reverse(answer), :lists.reverse(authority),
+     additional_in_order, parse_edns_info(additional_in_order)}
   end
 
   # Fast parsing functions with reduced overhead

--- a/test/dns_packet_roundtrip_test.exs
+++ b/test/dns_packet_roundtrip_test.exs
@@ -262,21 +262,18 @@ defmodule DNSpacketRoundtripTest do
                [{192, 0, 2, 53}, {192, 0, 2, 54}]
     end
 
-    # parse/1 currently returns every section in reverse wire order (records
-    # are accumulated by prepending without a final reverse). This pins the
-    # current behavior across all three sections; tracked in issue #98 —
-    # update the expectations below when that fix lands.
-    @tag :known_issue
-    test "sections are returned in reverse wire order (issue #98)" do
+    # Record order inside a section is semantically meaningful in DNS
+    # (CNAME chains, round-robin); parse/1 must preserve wire order (#98)
+    test "sections are returned in wire order" do
       parsed = roundtrip(multi_section_packet())
 
-      assert Enum.map(parsed.answer, & &1.rdata.addr) == [{192, 0, 2, 2}, {192, 0, 2, 1}]
+      assert Enum.map(parsed.answer, & &1.rdata.addr) == [{192, 0, 2, 1}, {192, 0, 2, 2}]
 
       assert Enum.map(parsed.authority, & &1.rdata.name) ==
-               ["ns2.example.com.", "ns1.example.com."]
+               ["ns1.example.com.", "ns2.example.com."]
 
       assert Enum.map(parsed.additional, & &1.rdata.addr) ==
-               [{192, 0, 2, 54}, {192, 0, 2, 53}]
+               [{192, 0, 2, 53}, {192, 0, 2, 54}]
     end
   end
 end


### PR DESCRIPTION
Resolves #98

## Summary

`parse/1` accumulated records by prepending and never reversed, so every section (question / answer / authority / additional) came back in **reverse wire order**. Record order is semantically meaningful in DNS (CNAME chains, round-robin), and a parse → create round-trip flipped section contents relative to the original wire bytes. This is a deliberate behavior change, kept out of the earlier behavior-preserving PRs by design.

## Change

One reverse per section in `parse_sections/6` (`:lists.reverse/1`), leaving the prepend-accumulation hot loop untouched. The additional section is reversed **before** the EDNS lookup so (invalid) multi-OPT packets resolve the same OPT record consistently.

## Tests (TDD)

- Flipped the `@tag :known_issue` pin from #99 into a regular wire-order test across all three sections (`mix test --only known_issue` is now empty) — confirmed red before the fix.
- Full suite: no other test relied on the reversed order; 221 passed unchanged in count.

## Verification

- `mix test --cover`: 221 passed, coverage 93.82%
- `mix credo --strict` / `mix dialyzer`: clean (an intermediate `additional` rebinding was caught by the Lefthook credo gate and renamed before landing)
- Bench gate (`bench/performance_bench.exs`, parse medians): simple 167 → 167 ns, complex 960 → 960 ns, EDNS 920 → 880 ns — within noise

## Downstream note

tdig will now display answers in wire order (previously reversed) — that is the intended behavior, no tdig change needed.