### PR TITLE
Refactor: use Enum.reverse for section ordering, matching codebase idiom

### DIFF
--- a/lib/dns_packet.ex
+++ b/lib/dns_packet.ex
@@ -789,10 +789,10 @@ defmodule DNSpacket do
     # round-robin), see issue #98. additional is reversed before the EDNS
     # lookup so that (invalid) multi-OPT packets resolve the same OPT record
     # as the wire order implies.
-    additional_in_order = :lists.reverse(additional)
+    additional_in_order = Enum.reverse(additional)
 
-    {:lists.reverse(question), :lists.reverse(answer), :lists.reverse(authority),
-     additional_in_order, parse_edns_info(additional_in_order)}
+    {Enum.reverse(question), Enum.reverse(answer), Enum.reverse(authority), additional_in_order,
+     parse_edns_info(additional_in_order)}
   end
 
   # Fast parsing functions with reduced overhead


### PR DESCRIPTION
Follow-up to #102 (post-merge review feedback).

## Summary

`parse_sections/6` used `:lists.reverse/1` while the other nine reverse sites in `lib/` — including the hotter, inlined `parse_name_acc/3` — all use `Enum.reverse/1`. For lists, `Enum.reverse/1` delegates directly to `:lists.reverse/1` (`def reverse(list) when is_list(list), do: :lists.reverse(list)` in Elixir core), so this is purely an idiom-consistency fix: behavior and performance are identical.

## Verification

- `mix test`: 221 passed unchanged (including the wire-order test from #102)
- Parse bench medians unchanged: 167 / 960 / 880 ns (simple / complex / EDNS)
- `mix credo --strict`: clean (via Lefthook on commit)