### PR TITLE
Fix: align ExDoc source_ref with unprefixed tag convention

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,8 @@ defmodule Tenbin.DNS.MixProject do
     [
       main: "Tenbin.DNS",
       name: "Tenbin.DNS",
-      source_ref: "v#{@version}",
+      # Tags are unprefixed (e.g. "0.8.0"); keep doc source links aligned
+      source_ref: @version,
       source_url: "https://github.com/smkwlab/tenbin_dns",
       extras: [
         "README.md",


### PR DESCRIPTION
Found while publishing the 0.8.0 release.

## Summary

`docs.source_ref` in `mix.exs` was `"v#{@version}"`, but actual tags are unprefixed (`0.7.1`, `0.8.0`, ...) — so every "view source" link in generated docs pointed at a nonexistent v-prefixed ref. One-line fix: `source_ref: @version`, with a comment noting the tag convention.

## Verification (real links)

- `mix docs` now emits `https://github.com/smkwlab/tenbin_dns/blob/0.8.0/lib/dns_packet.ex#L…`
- HTTP check: the new `blob/0.8.0/...` form returns **200**; the old `blob/v0.8.0/...` form returns **404** (confirming the bug was real)
- `mix test`: 225 passed; credo clean via Lefthook

## Note

The disabled tag trigger in `release.yml` (`tags: ['v*']`, commented out pending Hex publication) also assumes the v-prefix — worth aligning to `'[0-9]+.[0-9]+.[0-9]+'` (the tdig pattern) whenever that workflow is enabled. Left untouched here since it is dormant.