### PR TITLE
Extract per-type rdata codec into DNSpacket.RData

### DIFF
--- a/lib/dns_packet.ex
+++ b/lib/dns_packet.ex
@@ -137,26 +137,21 @@ defmodule DNSpacket do
   - Unknown options access: 32.9% faster
   """
 
-  import Bitwise
-
   alias DNSpacket.EDNS
+  alias DNSpacket.RData
 
   # Aggressive inlining for maximum speed (over memory efficiency)
   @compile {:inline,
-   [
-     create_character_string: 1,
-     add_rdlength: 1,
-     parse_name: 3,
-     parse_name_acc: 3,
-     parse_rdata: 4,
-     parse_sections: 6,
-     parse_question_fast: 4,
-     parse_answer_fast: 4,
-     parse_answer_checkopt_fast: 6,
-     # Fast paths for common DNS record types
-     parse_a_fast: 1,
-     parse_aaaa_fast: 1
-   ]}
+            [
+              create_character_string: 1,
+              add_rdlength: 1,
+              parse_name: 3,
+              parse_name_acc: 3,
+              parse_sections: 6,
+              parse_question_fast: 4,
+              parse_answer_fast: 4,
+              parse_answer_checkopt_fast: 6
+            ]}
 
   defstruct id: 0,
             qr: 0,
@@ -339,7 +334,7 @@ defmodule DNSpacket do
   def create_rr(rr) do
     create_domain_name(rr.name) <>
       <<DNS.type_code(rr.type)::16, DNS.class_code(rr.class)::16, rr.ttl::32>> <>
-      (rr.rdata |> create_rdata(rr.type, rr.class) |> add_rdlength)
+      (rr.rdata |> RData.encode(rr.type, rr.class) |> add_rdlength)
   end
 
   @doc false
@@ -365,307 +360,27 @@ defmodule DNSpacket do
     }
   end
 
+  # Per-type rdata codec lives in DNSpacket.RData (#111); these delegates
+  # keep the long-standing @doc false entry points stable for tests
   @doc false
-  def create_rdata(%{addr: {a, b, c, d}}, :a, :in) do
-    <<a::8, b::8, c::8, d::8>>
-  end
-
-  # :dname is kept separate from this group: its rdata field is .target, not .name
-  @doc false
-  def create_rdata(rdata, type, _) when type in [:ns, :cname, :ptr] do
-    create_domain_name(rdata.name)
-  end
+  defdelegate create_rdata(rdata, type, class), to: RData, as: :encode
 
   @doc false
-  def create_rdata(rdata, :soa, _) do
-    create_domain_name(rdata.mname) <>
-      create_domain_name(rdata.rname) <>
-      <<rdata.serial::32, rdata.refresh::32, rdata.retry::32, rdata.expire::32,
-        rdata.minimum::32>>
-  end
+  defdelegate parse_rdata(rdata, type, class, orig_body), to: RData, as: :decode
 
   @doc false
-  def create_rdata(rdata, :mx, _) do
-    <<rdata.preference::16>> <> create_domain_name(rdata.name)
-  end
+  defdelegate create_type_bitmap(types), to: RData
 
   @doc false
-  def create_rdata(rdata, :txt, _) do
-    create_character_strings(rdata.txt)
-  end
+  defdelegate parse_type_bitmap(data), to: RData
 
   @doc false
-  def create_rdata(rdata, :hinfo, _) do
-    <<byte_size(rdata.cpu)::8, rdata.cpu::binary, byte_size(rdata.os)::8, rdata.os::binary>>
-  end
+  defdelegate create_svc_params(params), to: RData
 
   @doc false
-  def create_rdata(%{addr: {a1, a2, a3, a4, a5, a6, a7, a8}}, :aaaa, :in) do
-    <<a1::16, a2::16, a3::16, a4::16, a5::16, a6::16, a7::16, a8::16>>
-  end
-
-  @doc false
-  def create_rdata(rdata, :caa, _) do
-    <<rdata.flag::8, byte_size(rdata.tag)::8, rdata.tag::binary, rdata.value::binary>>
-  end
-
-  @doc false
-  def create_rdata(rdata, :srv, _) do
-    <<rdata.priority::16, rdata.weight::16, rdata.port::16>> <> create_domain_name(rdata.target)
-  end
-
-  @doc false
-  def create_rdata(rdata, :naptr, _) do
-    <<rdata.order::16, rdata.preference::16, byte_size(rdata.flags)::8, rdata.flags::binary,
-      byte_size(rdata.services)::8, rdata.services::binary, byte_size(rdata.regexp)::8,
-      rdata.regexp::binary>> <>
-      create_domain_name(rdata.replacement)
-  end
-
-  @doc false
-  def create_rdata(rdata, :dname, _) do
-    create_domain_name(rdata.target)
-  end
-
-  @doc false
-  def create_rdata(rdata, :dnskey, _) do
-    <<rdata.flags::16, rdata.protocol::8, rdata.algorithm::8, rdata.public_key::binary>>
-  end
-
-  @doc false
-  def create_rdata(rdata, :ds, _) do
-    <<rdata.key_tag::16, rdata.algorithm::8, rdata.digest_type::8, rdata.digest::binary>>
-  end
-
-  @doc false
-  def create_rdata(rdata, :rrsig, _) do
-    <<rdata.type_covered::16, rdata.algorithm::8, rdata.labels::8, rdata.original_ttl::32,
-      rdata.signature_expiration::32, rdata.signature_inception::32, rdata.key_tag::16>> <>
-      create_domain_name(rdata.signer_name) <>
-      <<rdata.signature::binary>>
-  end
-
-  @doc false
-  def create_rdata(rdata, :nsec, _) do
-    create_domain_name(rdata.next_domain_name) <>
-      create_type_bitmap(rdata.type_bit_maps)
-  end
-
-  @doc false
-  def create_rdata(rdata, type, _) when type in [:svcb, :https] do
-    # SVCB/HTTPS support with Service Parameters
-    target_name = create_domain_name(rdata.target)
-    svc_params = create_svc_params(Map.get(rdata, :svc_params, %{}))
-    <<rdata.priority::16>> <> target_name <> svc_params
-  end
-
-  @doc false
-  def create_rdata(rdata, _, _) do
-    # Fallback for unknown types
-    rdata
-  end
+  defdelegate parse_svc_params(data), to: RData
 
   defp add_rdlength(rdata), do: <<byte_size(rdata)::16>> <> rdata
-
-  @doc false
-  def create_type_bitmap(type_list) when is_list(type_list) do
-    # Convert type atoms to numbers and create bitmap
-    type_numbers = Enum.map(type_list, &DNS.type_code/1)
-    create_type_bitmap_from_numbers(type_numbers)
-  end
-
-  def create_type_bitmap(bitmap) when is_binary(bitmap), do: bitmap
-
-  defp create_type_bitmap_from_numbers(type_numbers) do
-    # Group types by window (each window covers 256 types)
-    windows = Enum.group_by(type_numbers, &div(&1, 256))
-
-    # Create bitmap for each window
-    Enum.reduce(windows, <<>>, fn {window, types}, acc ->
-      bitmap = create_window_bitmap(types, window * 256)
-      window_data = <<window::8, byte_size(bitmap)::8, bitmap::binary>>
-      acc <> window_data
-    end)
-  end
-
-  defp create_window_bitmap(types, window_base) do
-    # Create bitmap for types within a window
-    relative_types = Enum.map(types, &(&1 - window_base))
-    max_type = Enum.max(relative_types)
-    byte_count = div(max_type, 8) + 1
-
-    # Initialize bitmap with zeros
-    bitmap = <<0::size(byte_count * 8)>>
-
-    # Set bits for each type
-    Enum.reduce(relative_types, bitmap, fn type, acc ->
-      byte_pos = div(type, 8)
-      bit_pos = 7 - rem(type, 8)
-      set_bit_in_bitmap(acc, byte_pos, bit_pos)
-    end)
-  end
-
-  defp set_bit_in_bitmap(bitmap, byte_pos, bit_pos) do
-    <<prefix::binary-size(^byte_pos), byte::8, suffix::binary>> = bitmap
-    new_byte = byte ||| 1 <<< bit_pos
-    prefix <> <<new_byte::8>> <> suffix
-  end
-
-  @doc false
-  def parse_type_bitmap(<<>>), do: []
-
-  def parse_type_bitmap(<<window::8, length::8, bitmap::binary-size(length), rest::binary>>) do
-    types = parse_window_bitmap(bitmap, window * 256)
-    types ++ parse_type_bitmap(rest)
-  end
-
-  # Return raw data if parsing fails
-  def parse_type_bitmap(data), do: data
-
-  defp parse_window_bitmap(bitmap, window_base) do
-    bitmap
-    |> :binary.bin_to_list()
-    |> Enum.with_index()
-    |> Enum.flat_map(fn {byte, byte_index} ->
-      parse_byte_bitmap(byte, window_base + byte_index * 8)
-    end)
-  end
-
-  defp parse_byte_bitmap(byte, base_type) do
-    0..7
-    |> Enum.filter(fn bit_pos ->
-      (byte &&& 1 <<< (7 - bit_pos)) != 0
-    end)
-    |> Enum.map(fn bit_pos ->
-      type_code = base_type + bit_pos
-      DNS.type(type_code) || type_code
-    end)
-  end
-
-  @doc false
-  def create_svc_params(params) when is_map(params) do
-    params
-    |> Enum.sort_by(fn {key, _} -> svc_param_key_code(key) end)
-    |> Enum.map(&create_svc_param/1)
-    |> IO.iodata_to_binary()
-  end
-
-  def create_svc_params(_), do: <<>>
-
-  defp create_svc_param({:alpn, alpn_list}) when is_list(alpn_list) do
-    alpn_data =
-      alpn_list
-      |> Enum.map(&create_character_string/1)
-      |> IO.iodata_to_binary()
-
-    <<1::16, byte_size(alpn_data)::16, alpn_data::binary>>
-  end
-
-  defp create_svc_param({:port, port}) when is_integer(port) do
-    <<3::16, 2::16, port::16>>
-  end
-
-  defp create_svc_param({:ipv4_hints, ip_list}) when is_list(ip_list) do
-    ip_data =
-      ip_list
-      |> Enum.map(fn {a, b, c, d} -> <<a::8, b::8, c::8, d::8>> end)
-      |> IO.iodata_to_binary()
-
-    <<4::16, byte_size(ip_data)::16, ip_data::binary>>
-  end
-
-  defp create_svc_param({:ipv6_hints, ip_list}) when is_list(ip_list) do
-    ip_data =
-      ip_list
-      |> Enum.map(fn {a1, a2, a3, a4, a5, a6, a7, a8} ->
-        <<a1::16, a2::16, a3::16, a4::16, a5::16, a6::16, a7::16, a8::16>>
-      end)
-      |> IO.iodata_to_binary()
-
-    <<6::16, byte_size(ip_data)::16, ip_data::binary>>
-  end
-
-  defp create_svc_param({key, value}) when is_integer(key) and is_binary(value) do
-    # Generic parameter
-    <<key::16, byte_size(value)::16, value::binary>>
-  end
-
-  defp create_svc_param(_), do: <<>>
-
-  defp svc_param_key_code(:mandatory), do: 0
-  defp svc_param_key_code(:alpn), do: 1
-  defp svc_param_key_code(:no_default_alpn), do: 2
-  defp svc_param_key_code(:port), do: 3
-  defp svc_param_key_code(:ipv4_hints), do: 4
-  defp svc_param_key_code(:ech), do: 5
-  defp svc_param_key_code(:ipv6_hints), do: 6
-  defp svc_param_key_code(key) when is_integer(key), do: key
-  defp svc_param_key_code(_), do: 65_535
-
-  @doc false
-  def parse_svc_params(<<>>), do: %{}
-
-  def parse_svc_params(<<key::16, length::16, value::binary-size(length), rest::binary>>) do
-    param = parse_svc_param(key, value)
-    Map.merge(param, parse_svc_params(rest))
-  end
-
-  def parse_svc_params(_), do: %{}
-
-  defp parse_svc_param(1, alpn_data) do
-    # ALPN parameter
-    alpn_list = parse_alpn_list(alpn_data, [])
-    %{alpn: alpn_list}
-  end
-
-  defp parse_svc_param(3, <<port::16>>) do
-    # Port parameter
-    %{port: port}
-  end
-
-  defp parse_svc_param(4, ip_data) do
-    # IPv4 hints
-    ipv4_list = parse_ipv4_hints(ip_data, [])
-    %{ipv4_hints: ipv4_list}
-  end
-
-  defp parse_svc_param(6, ip_data) do
-    # IPv6 hints
-    ipv6_list = parse_ipv6_hints(ip_data, [])
-    %{ipv6_hints: ipv6_list}
-  end
-
-  defp parse_svc_param(key, value) do
-    # Generic parameter
-    %{key => value}
-  end
-
-  defp parse_alpn_list(<<>>, acc), do: Enum.reverse(acc)
-
-  defp parse_alpn_list(<<length::8, alpn::binary-size(length), rest::binary>>, acc) do
-    parse_alpn_list(rest, [alpn | acc])
-  end
-
-  defp parse_alpn_list(_, acc), do: Enum.reverse(acc)
-
-  defp parse_ipv4_hints(<<>>, acc), do: Enum.reverse(acc)
-
-  defp parse_ipv4_hints(<<a::8, b::8, c::8, d::8, rest::binary>>, acc) do
-    parse_ipv4_hints(rest, [{a, b, c, d} | acc])
-  end
-
-  defp parse_ipv4_hints(_, acc), do: Enum.reverse(acc)
-
-  defp parse_ipv6_hints(<<>>, acc), do: Enum.reverse(acc)
-
-  defp parse_ipv6_hints(
-         <<a1::16, a2::16, a3::16, a4::16, a5::16, a6::16, a7::16, a8::16, rest::binary>>,
-         acc
-       ) do
-    parse_ipv6_hints(rest, [{a1, a2, a3, a4, a5, a6, a7, a8} | acc])
-  end
-
-  defp parse_ipv6_hints(_, acc), do: Enum.reverse(acc)
 
   @doc false
   def create_domain_name(name) do
@@ -678,41 +393,6 @@ defmodule DNSpacket do
 
   @doc false
   def create_character_string(txt), do: <<byte_size(txt)::8, txt::binary>>
-
-  # Encode a binary as consecutive character-strings of at most 255 bytes
-  # each (RFC 1035 §3.3.14); values up to 255 bytes produce the same single
-  # character-string as before. Chunks are collected as iodata to avoid
-  # repeated binary copying on long values.
-  defp create_character_strings(txt) when byte_size(txt) <= 255 do
-    create_character_string(txt)
-  end
-
-  defp create_character_strings(txt) do
-    txt |> chunk_character_strings([]) |> IO.iodata_to_binary()
-  end
-
-  # The terminal clause receives 1..255 bytes: the caller only enters the
-  # loop with > 255 bytes, so the remainder after a 255-byte chunk is >= 1
-  defp chunk_character_strings(txt, acc) when byte_size(txt) <= 255 do
-    Enum.reverse([create_character_string(txt) | acc])
-  end
-
-  defp chunk_character_strings(<<chunk::binary-size(255), rest::binary>>, acc) do
-    chunk_character_strings(rest, [create_character_string(chunk) | acc])
-  end
-
-  # Decode consecutive character-strings into their concatenation. Once a
-  # length byte overruns the remaining data, that string and everything after
-  # it is discarded — whether it is a truncated trailing string or a bogus
-  # mid-stream length (graceful degradation; see "Malformed Input" in the
-  # parse/1 docs)
-  defp parse_character_strings(<<length::8, txt::binary-size(length), rest::binary>>, acc) do
-    parse_character_strings(rest, [txt | acc])
-  end
-
-  defp parse_character_strings(_, acc) do
-    acc |> Enum.reverse() |> IO.iodata_to_binary()
-  end
 
   @doc """
   Parses a DNS packet binary into a DNSpacket struct.
@@ -918,18 +598,21 @@ defmodule DNSpacket do
         class: class_atom,
         ttl: ttl,
         rdlength: rdlength,
-        rdata: parse_rdata(rdata, type_atom || type, class_atom || class, orig_body)
+        rdata: RData.decode(rdata, type_atom || type, class_atom || class, orig_body)
       }
       | result
     ])
   end
 
-  # Optimized parse_name using iolist accumulator for better performance
-  defp parse_name(body, orig_body, "") do
+  # Optimized parse_name using iolist accumulator for better performance.
+  # Public (@doc false) because DNSpacket.RData decodes embedded domain
+  # names with it; local callers still get the @compile :inline benefit
+  @doc false
+  def parse_name(body, orig_body, "") do
     parse_name_acc(body, orig_body, [])
   end
 
-  defp parse_name(body, orig_body, result) do
+  def parse_name(body, orig_body, result) do
     parse_name_acc(body, orig_body, [result])
   end
 
@@ -949,250 +632,6 @@ defmodule DNSpacket do
 
   defp parse_name_acc(<<length::8, name::binary-size(length), body::binary>>, orig_body, acc) do
     parse_name_acc(body, orig_body, ["." | [name | acc]])
-  end
-
-  # Fast paths for A and AAAA records
-  # Direct pattern matching with no function call overhead
-  @doc false
-  def parse_a_fast(<<a::8, b::8, c::8, d::8>>), do: %{addr: {a, b, c, d}}
-
-  @doc false
-  def parse_aaaa_fast(<<a1::16, a2::16, a3::16, a4::16, a5::16, a6::16, a7::16, a8::16>>) do
-    %{addr: {a1, a2, a3, a4, a5, a6, a7, a8}}
-  end
-
-  # Optimized parse_rdata using fast paths with fallback to original behavior
-  @doc false
-  def parse_rdata(<<a::8, b::8, c::8, d::8>>, :a, :in, _), do: parse_a_fast(<<a, b, c, d>>)
-  @doc false
-  def parse_rdata(
-        <<a1::16, a2::16, a3::16, a4::16, a5::16, a6::16, a7::16, a8::16>>,
-        :aaaa,
-        :in,
-        _
-      ) do
-    parse_aaaa_fast(<<a1::16, a2::16, a3::16, a4::16, a5::16, a6::16, a7::16, a8::16>>)
-  end
-
-  # :dname is kept separate from this group: its rdata field is .target, not .name
-  @doc false
-  def parse_rdata(rdata, type, _, orig_body) when type in [:ns, :cname, :ptr] do
-    {_, _, name} = parse_name(rdata, orig_body, "")
-
-    %{
-      name: name
-    }
-  end
-
-  @doc false
-  def parse_rdata(rdata, :soa, _, orig_body) do
-    {rest1, _, mname} = parse_name(rdata, orig_body, "")
-    {rest2, _, rname} = parse_name(rest1, orig_body, "")
-
-    <<
-      serial::unsigned-integer-size(32),
-      refresh::unsigned-integer-size(32),
-      retry::unsigned-integer-size(32),
-      expire::unsigned-integer-size(32),
-      minimum::unsigned-integer-size(32)
-    >> = rest2
-
-    %{
-      mname: mname,
-      rname: rname,
-      serial: serial,
-      refresh: refresh,
-      retry: retry,
-      expire: expire,
-      minimum: minimum
-    }
-  end
-
-  @doc false
-  def parse_rdata(
-        <<cpu_length::unsigned-integer-size(8), cpu::binary-size(cpu_length),
-          os_length::unsigned-integer-size(8), os::binary-size(os_length)>>,
-        :hinfo,
-        _,
-        _
-      ) do
-    %{
-      cpu: cpu,
-      os: os
-    }
-  end
-
-  @doc false
-  def parse_rdata(<<preference::unsigned-integer-size(16), tmp_body::binary>>, :mx, _, orig_body) do
-    {_, _, name} = parse_name(tmp_body, orig_body, "")
-
-    %{
-      preference: preference,
-      name: name
-    }
-  end
-
-  # RFC 1035 allows multiple character-strings per TXT record; the logical
-  # value is their concatenation (cf. RFC 7208 §3.3 for SPF). String
-  # boundaries are not preserved (see issue #95).
-  @doc false
-  def parse_rdata(rdata, :txt, _, _) do
-    %{
-      txt: parse_character_strings(rdata, [])
-    }
-  end
-
-  @doc false
-  def parse_rdata(
-        <<flag::unsigned-integer-size(8), tag_length::unsigned-integer-size(8),
-          tag::binary-size(tag_length), value::binary>>,
-        :caa,
-        _,
-        _
-      ) do
-    %{
-      flag: flag,
-      tag: tag,
-      value: value
-    }
-  end
-
-  @doc false
-  def parse_rdata(
-        <<priority::unsigned-integer-size(16), weight::unsigned-integer-size(16),
-          port::unsigned-integer-size(16), tmp_body::binary>>,
-        :srv,
-        _,
-        orig_body
-      ) do
-    {_, _, target} = parse_name(tmp_body, orig_body, "")
-
-    %{
-      priority: priority,
-      weight: weight,
-      port: port,
-      target: target
-    }
-  end
-
-  @doc false
-  def parse_rdata(
-        <<order::unsigned-integer-size(16), preference::unsigned-integer-size(16),
-          flags_len::unsigned-integer-size(8), flags::binary-size(flags_len),
-          services_len::unsigned-integer-size(8), services::binary-size(services_len),
-          regexp_len::unsigned-integer-size(8), regexp::binary-size(regexp_len),
-          tmp_body::binary>>,
-        :naptr,
-        _,
-        orig_body
-      ) do
-    {_, _, replacement} = parse_name(tmp_body, orig_body, "")
-
-    %{
-      order: order,
-      preference: preference,
-      flags: flags,
-      services: services,
-      regexp: regexp,
-      replacement: replacement
-    }
-  end
-
-  @doc false
-  def parse_rdata(rdata, :dname, _, orig_body) do
-    {_, _, target} = parse_name(rdata, orig_body, "")
-
-    %{
-      target: target
-    }
-  end
-
-  @doc false
-  def parse_rdata(
-        <<flags::unsigned-integer-size(16), protocol::unsigned-integer-size(8),
-          algorithm::unsigned-integer-size(8), public_key::binary>>,
-        :dnskey,
-        _,
-        _
-      ) do
-    %{
-      flags: flags,
-      protocol: protocol,
-      algorithm: algorithm,
-      public_key: public_key
-    }
-  end
-
-  @doc false
-  def parse_rdata(
-        <<key_tag::unsigned-integer-size(16), algorithm::unsigned-integer-size(8),
-          digest_type::unsigned-integer-size(8), digest::binary>>,
-        :ds,
-        _,
-        _
-      ) do
-    %{
-      key_tag: key_tag,
-      algorithm: algorithm,
-      digest_type: digest_type,
-      digest: digest
-    }
-  end
-
-  @doc false
-  def parse_rdata(
-        <<type_covered::unsigned-integer-size(16), algorithm::unsigned-integer-size(8),
-          labels::unsigned-integer-size(8), original_ttl::unsigned-integer-size(32),
-          signature_expiration::unsigned-integer-size(32),
-          signature_inception::unsigned-integer-size(32), key_tag::unsigned-integer-size(16),
-          tmp_body::binary>>,
-        :rrsig,
-        _,
-        orig_body
-      ) do
-    {rest, _, signer_name} = parse_name(tmp_body, orig_body, "")
-
-    %{
-      type_covered: type_covered,
-      algorithm: algorithm,
-      labels: labels,
-      original_ttl: original_ttl,
-      signature_expiration: signature_expiration,
-      signature_inception: signature_inception,
-      key_tag: key_tag,
-      signer_name: signer_name,
-      signature: rest
-    }
-  end
-
-  @doc false
-  def parse_rdata(rdata, :nsec, _, orig_body) do
-    {rest, _, next_domain_name} = parse_name(rdata, orig_body, "")
-    type_bit_maps = parse_type_bitmap(rest)
-
-    %{
-      next_domain_name: next_domain_name,
-      type_bit_maps: type_bit_maps
-    }
-  end
-
-  @doc false
-  def parse_rdata(<<priority::unsigned-integer-size(16), tmp_body::binary>>, type, _, orig_body)
-      when type in [:svcb, :https] do
-    # SVCB/HTTPS support with Service Parameters
-    {rest, _, target} = parse_name(tmp_body, orig_body, "")
-    svc_params = parse_svc_params(rest)
-
-    %{
-      priority: priority,
-      target: target,
-      svc_params: svc_params
-    }
-  end
-
-  @doc false
-  def parse_rdata(rdata, type, class, _) do
-    %{type: type, class: class, rdata: rdata}
   end
 
   @doc false

--- a/lib/dns_packet/rdata.ex
+++ b/lib/dns_packet/rdata.ex
@@ -1,0 +1,619 @@
+defmodule DNSpacket.RData do
+  @moduledoc """
+  Per-record-type rdata codec for DNS packets (#111).
+
+  All knowledge about how a record type's rdata is laid out on the wire
+  lives here: `encode/3` clauses build rdata binaries, `decode/4` clauses
+  parse them back into the canonical rdata maps. Clauses are grouped by
+  function (compiler requirement) and ordered the same way in both
+  directions so a type's encode and decode stay easy to compare.
+
+  Shared name codec (`create_domain_name/1`, `parse_name/3`,
+  `create_character_string/1`) intentionally stays in `DNSpacket`: it is
+  also used by the question/record framing on the hot parse/create paths,
+  where the local calls keep their `@compile :inline` benefit.
+
+  The round-trip contract is pinned by dns_packet_roundtrip_test.exs and
+  the property suite (#107).
+  """
+
+  import Bitwise
+
+  # Fast paths keep their inlining within this module
+  @compile {:inline,
+            [
+              parse_a_fast: 1,
+              parse_aaaa_fast: 1
+            ]}
+
+  # --- encode --------------------------------------------------------
+
+  @doc false
+  def encode(%{addr: {a, b, c, d}}, :a, :in) do
+    <<a::8, b::8, c::8, d::8>>
+  end
+
+  # :dname is kept separate from this group: its rdata field is .target, not .name
+  @doc false
+  def encode(rdata, type, _) when type in [:ns, :cname, :ptr] do
+    DNSpacket.create_domain_name(rdata.name)
+  end
+
+  @doc false
+  def encode(rdata, :soa, _) do
+    DNSpacket.create_domain_name(rdata.mname) <>
+      DNSpacket.create_domain_name(rdata.rname) <>
+      <<rdata.serial::32, rdata.refresh::32, rdata.retry::32, rdata.expire::32,
+        rdata.minimum::32>>
+  end
+
+  @doc false
+  def encode(rdata, :mx, _) do
+    <<rdata.preference::16>> <> DNSpacket.create_domain_name(rdata.name)
+  end
+
+  @doc false
+  def encode(rdata, :txt, _) do
+    create_character_strings(rdata.txt)
+  end
+
+  @doc false
+  def encode(rdata, :hinfo, _) do
+    <<byte_size(rdata.cpu)::8, rdata.cpu::binary, byte_size(rdata.os)::8, rdata.os::binary>>
+  end
+
+  @doc false
+  def encode(%{addr: {a1, a2, a3, a4, a5, a6, a7, a8}}, :aaaa, :in) do
+    <<a1::16, a2::16, a3::16, a4::16, a5::16, a6::16, a7::16, a8::16>>
+  end
+
+  @doc false
+  def encode(rdata, :caa, _) do
+    <<rdata.flag::8, byte_size(rdata.tag)::8, rdata.tag::binary, rdata.value::binary>>
+  end
+
+  @doc false
+  def encode(rdata, :srv, _) do
+    <<rdata.priority::16, rdata.weight::16, rdata.port::16>> <>
+      DNSpacket.create_domain_name(rdata.target)
+  end
+
+  @doc false
+  def encode(rdata, :naptr, _) do
+    <<rdata.order::16, rdata.preference::16, byte_size(rdata.flags)::8, rdata.flags::binary,
+      byte_size(rdata.services)::8, rdata.services::binary, byte_size(rdata.regexp)::8,
+      rdata.regexp::binary>> <>
+      DNSpacket.create_domain_name(rdata.replacement)
+  end
+
+  @doc false
+  def encode(rdata, :dname, _) do
+    DNSpacket.create_domain_name(rdata.target)
+  end
+
+  @doc false
+  def encode(rdata, :dnskey, _) do
+    <<rdata.flags::16, rdata.protocol::8, rdata.algorithm::8, rdata.public_key::binary>>
+  end
+
+  @doc false
+  def encode(rdata, :ds, _) do
+    <<rdata.key_tag::16, rdata.algorithm::8, rdata.digest_type::8, rdata.digest::binary>>
+  end
+
+  @doc false
+  def encode(rdata, :rrsig, _) do
+    <<rdata.type_covered::16, rdata.algorithm::8, rdata.labels::8, rdata.original_ttl::32,
+      rdata.signature_expiration::32, rdata.signature_inception::32, rdata.key_tag::16>> <>
+      DNSpacket.create_domain_name(rdata.signer_name) <>
+      <<rdata.signature::binary>>
+  end
+
+  @doc false
+  def encode(rdata, :nsec, _) do
+    DNSpacket.create_domain_name(rdata.next_domain_name) <>
+      create_type_bitmap(rdata.type_bit_maps)
+  end
+
+  @doc false
+  def encode(rdata, type, _) when type in [:svcb, :https] do
+    # SVCB/HTTPS support with Service Parameters
+    target_name = DNSpacket.create_domain_name(rdata.target)
+    svc_params = create_svc_params(Map.get(rdata, :svc_params, %{}))
+    <<rdata.priority::16>> <> target_name <> svc_params
+  end
+
+  @doc false
+  def encode(rdata, _, _) do
+    # Fallback for unknown types
+    rdata
+  end
+
+  # --- decode --------------------------------------------------------
+
+  # Fast paths for A and AAAA records
+  # Direct pattern matching with no function call overhead
+  @doc false
+  def parse_a_fast(<<a::8, b::8, c::8, d::8>>), do: %{addr: {a, b, c, d}}
+
+  @doc false
+  def parse_aaaa_fast(<<a1::16, a2::16, a3::16, a4::16, a5::16, a6::16, a7::16, a8::16>>) do
+    %{addr: {a1, a2, a3, a4, a5, a6, a7, a8}}
+  end
+
+  # Optimized decode using fast paths with fallback to original behavior
+  @doc false
+  def decode(<<a::8, b::8, c::8, d::8>>, :a, :in, _), do: parse_a_fast(<<a, b, c, d>>)
+
+  @doc false
+  def decode(
+        <<a1::16, a2::16, a3::16, a4::16, a5::16, a6::16, a7::16, a8::16>>,
+        :aaaa,
+        :in,
+        _
+      ) do
+    parse_aaaa_fast(<<a1::16, a2::16, a3::16, a4::16, a5::16, a6::16, a7::16, a8::16>>)
+  end
+
+  # :dname is kept separate from this group: its rdata field is .target, not .name
+  @doc false
+  def decode(rdata, type, _, orig_body) when type in [:ns, :cname, :ptr] do
+    {_, _, name} = DNSpacket.parse_name(rdata, orig_body, "")
+
+    %{
+      name: name
+    }
+  end
+
+  @doc false
+  def decode(rdata, :soa, _, orig_body) do
+    {rest1, _, mname} = DNSpacket.parse_name(rdata, orig_body, "")
+    {rest2, _, rname} = DNSpacket.parse_name(rest1, orig_body, "")
+
+    <<
+      serial::unsigned-integer-size(32),
+      refresh::unsigned-integer-size(32),
+      retry::unsigned-integer-size(32),
+      expire::unsigned-integer-size(32),
+      minimum::unsigned-integer-size(32)
+    >> = rest2
+
+    %{
+      mname: mname,
+      rname: rname,
+      serial: serial,
+      refresh: refresh,
+      retry: retry,
+      expire: expire,
+      minimum: minimum
+    }
+  end
+
+  @doc false
+  def decode(
+        <<cpu_length::unsigned-integer-size(8), cpu::binary-size(cpu_length),
+          os_length::unsigned-integer-size(8), os::binary-size(os_length)>>,
+        :hinfo,
+        _,
+        _
+      ) do
+    %{
+      cpu: cpu,
+      os: os
+    }
+  end
+
+  @doc false
+  def decode(<<preference::unsigned-integer-size(16), tmp_body::binary>>, :mx, _, orig_body) do
+    {_, _, name} = DNSpacket.parse_name(tmp_body, orig_body, "")
+
+    %{
+      preference: preference,
+      name: name
+    }
+  end
+
+  # RFC 1035 allows multiple character-strings per TXT record; the logical
+  # value is their concatenation (cf. RFC 7208 §3.3 for SPF). String
+  # boundaries are not preserved (see issue #95).
+  @doc false
+  def decode(rdata, :txt, _, _) do
+    %{
+      txt: parse_character_strings(rdata, [])
+    }
+  end
+
+  @doc false
+  def decode(
+        <<flag::unsigned-integer-size(8), tag_length::unsigned-integer-size(8),
+          tag::binary-size(tag_length), value::binary>>,
+        :caa,
+        _,
+        _
+      ) do
+    %{
+      flag: flag,
+      tag: tag,
+      value: value
+    }
+  end
+
+  @doc false
+  def decode(
+        <<priority::unsigned-integer-size(16), weight::unsigned-integer-size(16),
+          port::unsigned-integer-size(16), tmp_body::binary>>,
+        :srv,
+        _,
+        orig_body
+      ) do
+    {_, _, target} = DNSpacket.parse_name(tmp_body, orig_body, "")
+
+    %{
+      priority: priority,
+      weight: weight,
+      port: port,
+      target: target
+    }
+  end
+
+  @doc false
+  def decode(
+        <<order::unsigned-integer-size(16), preference::unsigned-integer-size(16),
+          flags_len::unsigned-integer-size(8), flags::binary-size(flags_len),
+          services_len::unsigned-integer-size(8), services::binary-size(services_len),
+          regexp_len::unsigned-integer-size(8), regexp::binary-size(regexp_len),
+          tmp_body::binary>>,
+        :naptr,
+        _,
+        orig_body
+      ) do
+    {_, _, replacement} = DNSpacket.parse_name(tmp_body, orig_body, "")
+
+    %{
+      order: order,
+      preference: preference,
+      flags: flags,
+      services: services,
+      regexp: regexp,
+      replacement: replacement
+    }
+  end
+
+  @doc false
+  def decode(rdata, :dname, _, orig_body) do
+    {_, _, target} = DNSpacket.parse_name(rdata, orig_body, "")
+
+    %{
+      target: target
+    }
+  end
+
+  @doc false
+  def decode(
+        <<flags::unsigned-integer-size(16), protocol::unsigned-integer-size(8),
+          algorithm::unsigned-integer-size(8), public_key::binary>>,
+        :dnskey,
+        _,
+        _
+      ) do
+    %{
+      flags: flags,
+      protocol: protocol,
+      algorithm: algorithm,
+      public_key: public_key
+    }
+  end
+
+  @doc false
+  def decode(
+        <<key_tag::unsigned-integer-size(16), algorithm::unsigned-integer-size(8),
+          digest_type::unsigned-integer-size(8), digest::binary>>,
+        :ds,
+        _,
+        _
+      ) do
+    %{
+      key_tag: key_tag,
+      algorithm: algorithm,
+      digest_type: digest_type,
+      digest: digest
+    }
+  end
+
+  @doc false
+  def decode(
+        <<type_covered::unsigned-integer-size(16), algorithm::unsigned-integer-size(8),
+          labels::unsigned-integer-size(8), original_ttl::unsigned-integer-size(32),
+          signature_expiration::unsigned-integer-size(32),
+          signature_inception::unsigned-integer-size(32), key_tag::unsigned-integer-size(16),
+          tmp_body::binary>>,
+        :rrsig,
+        _,
+        orig_body
+      ) do
+    {rest, _, signer_name} = DNSpacket.parse_name(tmp_body, orig_body, "")
+
+    %{
+      type_covered: type_covered,
+      algorithm: algorithm,
+      labels: labels,
+      original_ttl: original_ttl,
+      signature_expiration: signature_expiration,
+      signature_inception: signature_inception,
+      key_tag: key_tag,
+      signer_name: signer_name,
+      signature: rest
+    }
+  end
+
+  @doc false
+  def decode(rdata, :nsec, _, orig_body) do
+    {rest, _, next_domain_name} = DNSpacket.parse_name(rdata, orig_body, "")
+    type_bit_maps = parse_type_bitmap(rest)
+
+    %{
+      next_domain_name: next_domain_name,
+      type_bit_maps: type_bit_maps
+    }
+  end
+
+  @doc false
+  def decode(<<priority::unsigned-integer-size(16), tmp_body::binary>>, type, _, orig_body)
+      when type in [:svcb, :https] do
+    # SVCB/HTTPS support with Service Parameters
+    {rest, _, target} = DNSpacket.parse_name(tmp_body, orig_body, "")
+    svc_params = parse_svc_params(rest)
+
+    %{
+      priority: priority,
+      target: target,
+      svc_params: svc_params
+    }
+  end
+
+  @doc false
+  def decode(rdata, type, class, _) do
+    %{type: type, class: class, rdata: rdata}
+  end
+
+  # --- character strings (TXT) ---------------------------------------
+
+  # Encode a binary as consecutive character-strings of at most 255 bytes
+  # each (RFC 1035 §3.3.14); values up to 255 bytes produce the same single
+  # character-string as before. Chunks are collected as iodata to avoid
+  # repeated binary copying on long values.
+  defp create_character_strings(txt) when byte_size(txt) <= 255 do
+    DNSpacket.create_character_string(txt)
+  end
+
+  defp create_character_strings(txt) do
+    txt |> chunk_character_strings([]) |> IO.iodata_to_binary()
+  end
+
+  # The terminal clause receives 1..255 bytes: the caller only enters the
+  # loop with > 255 bytes, so the remainder after a 255-byte chunk is >= 1
+  defp chunk_character_strings(txt, acc) when byte_size(txt) <= 255 do
+    Enum.reverse([DNSpacket.create_character_string(txt) | acc])
+  end
+
+  defp chunk_character_strings(<<chunk::binary-size(255), rest::binary>>, acc) do
+    chunk_character_strings(rest, [DNSpacket.create_character_string(chunk) | acc])
+  end
+
+  # Decode consecutive character-strings into their concatenation. Once a
+  # length byte overruns the remaining data, that string and everything after
+  # it is discarded — whether it is a truncated trailing string or a bogus
+  # mid-stream length (graceful degradation; see "Malformed Input" in the
+  # DNSpacket.parse/1 docs)
+  defp parse_character_strings(<<length::8, txt::binary-size(length), rest::binary>>, acc) do
+    parse_character_strings(rest, [txt | acc])
+  end
+
+  defp parse_character_strings(_, acc) do
+    acc |> Enum.reverse() |> IO.iodata_to_binary()
+  end
+
+  # --- NSEC type bitmap ----------------------------------------------
+
+  @doc false
+  def create_type_bitmap(type_list) when is_list(type_list) do
+    # Convert type atoms to numbers and create bitmap
+    type_numbers = Enum.map(type_list, &DNS.type_code/1)
+    create_type_bitmap_from_numbers(type_numbers)
+  end
+
+  def create_type_bitmap(bitmap) when is_binary(bitmap), do: bitmap
+
+  defp create_type_bitmap_from_numbers(type_numbers) do
+    # Group types by window (each window covers 256 types)
+    windows = Enum.group_by(type_numbers, &div(&1, 256))
+
+    # Create bitmap for each window
+    Enum.reduce(windows, <<>>, fn {window, types}, acc ->
+      bitmap = create_window_bitmap(types, window * 256)
+      window_data = <<window::8, byte_size(bitmap)::8, bitmap::binary>>
+      acc <> window_data
+    end)
+  end
+
+  defp create_window_bitmap(types, window_base) do
+    # Create bitmap for types within a window
+    relative_types = Enum.map(types, &(&1 - window_base))
+    max_type = Enum.max(relative_types)
+    byte_count = div(max_type, 8) + 1
+
+    # Initialize bitmap with zeros
+    bitmap = <<0::size(byte_count * 8)>>
+
+    # Set bits for each type
+    Enum.reduce(relative_types, bitmap, fn type, acc ->
+      byte_pos = div(type, 8)
+      bit_pos = 7 - rem(type, 8)
+      set_bit_in_bitmap(acc, byte_pos, bit_pos)
+    end)
+  end
+
+  defp set_bit_in_bitmap(bitmap, byte_pos, bit_pos) do
+    <<prefix::binary-size(^byte_pos), byte::8, suffix::binary>> = bitmap
+    new_byte = byte ||| 1 <<< bit_pos
+    prefix <> <<new_byte::8>> <> suffix
+  end
+
+  @doc false
+  def parse_type_bitmap(<<>>), do: []
+
+  def parse_type_bitmap(<<window::8, length::8, bitmap::binary-size(length), rest::binary>>) do
+    types = parse_window_bitmap(bitmap, window * 256)
+    types ++ parse_type_bitmap(rest)
+  end
+
+  # Return raw data if parsing fails
+  def parse_type_bitmap(data), do: data
+
+  defp parse_window_bitmap(bitmap, window_base) do
+    bitmap
+    |> :binary.bin_to_list()
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {byte, byte_index} ->
+      parse_byte_bitmap(byte, window_base + byte_index * 8)
+    end)
+  end
+
+  defp parse_byte_bitmap(byte, base_type) do
+    0..7
+    |> Enum.filter(fn bit_pos ->
+      (byte &&& 1 <<< (7 - bit_pos)) != 0
+    end)
+    |> Enum.map(fn bit_pos ->
+      type_code = base_type + bit_pos
+      DNS.type(type_code) || type_code
+    end)
+  end
+
+  # --- SVCB/HTTPS service parameters ---------------------------------
+
+  @doc false
+  def create_svc_params(params) when is_map(params) do
+    params
+    |> Enum.sort_by(fn {key, _} -> svc_param_key_code(key) end)
+    |> Enum.map(&create_svc_param/1)
+    |> IO.iodata_to_binary()
+  end
+
+  def create_svc_params(_), do: <<>>
+
+  defp create_svc_param({:alpn, alpn_list}) when is_list(alpn_list) do
+    alpn_data =
+      alpn_list
+      |> Enum.map(&DNSpacket.create_character_string/1)
+      |> IO.iodata_to_binary()
+
+    <<1::16, byte_size(alpn_data)::16, alpn_data::binary>>
+  end
+
+  defp create_svc_param({:port, port}) when is_integer(port) do
+    <<3::16, 2::16, port::16>>
+  end
+
+  defp create_svc_param({:ipv4_hints, ip_list}) when is_list(ip_list) do
+    ip_data =
+      ip_list
+      |> Enum.map(fn {a, b, c, d} -> <<a::8, b::8, c::8, d::8>> end)
+      |> IO.iodata_to_binary()
+
+    <<4::16, byte_size(ip_data)::16, ip_data::binary>>
+  end
+
+  defp create_svc_param({:ipv6_hints, ip_list}) when is_list(ip_list) do
+    ip_data =
+      ip_list
+      |> Enum.map(fn {a1, a2, a3, a4, a5, a6, a7, a8} ->
+        <<a1::16, a2::16, a3::16, a4::16, a5::16, a6::16, a7::16, a8::16>>
+      end)
+      |> IO.iodata_to_binary()
+
+    <<6::16, byte_size(ip_data)::16, ip_data::binary>>
+  end
+
+  defp create_svc_param({key, value}) when is_integer(key) and is_binary(value) do
+    # Generic parameter
+    <<key::16, byte_size(value)::16, value::binary>>
+  end
+
+  defp create_svc_param(_), do: <<>>
+
+  defp svc_param_key_code(:mandatory), do: 0
+  defp svc_param_key_code(:alpn), do: 1
+  defp svc_param_key_code(:no_default_alpn), do: 2
+  defp svc_param_key_code(:port), do: 3
+  defp svc_param_key_code(:ipv4_hints), do: 4
+  defp svc_param_key_code(:ech), do: 5
+  defp svc_param_key_code(:ipv6_hints), do: 6
+  defp svc_param_key_code(key) when is_integer(key), do: key
+  defp svc_param_key_code(_), do: 65_535
+
+  @doc false
+  def parse_svc_params(<<>>), do: %{}
+
+  def parse_svc_params(<<key::16, length::16, value::binary-size(length), rest::binary>>) do
+    param = parse_svc_param(key, value)
+    Map.merge(param, parse_svc_params(rest))
+  end
+
+  def parse_svc_params(_), do: %{}
+
+  defp parse_svc_param(1, alpn_data) do
+    # ALPN parameter
+    alpn_list = parse_alpn_list(alpn_data, [])
+    %{alpn: alpn_list}
+  end
+
+  defp parse_svc_param(3, <<port::16>>) do
+    # Port parameter
+    %{port: port}
+  end
+
+  defp parse_svc_param(4, ip_data) do
+    # IPv4 hints
+    ipv4_list = parse_ipv4_hints(ip_data, [])
+    %{ipv4_hints: ipv4_list}
+  end
+
+  defp parse_svc_param(6, ip_data) do
+    # IPv6 hints
+    ipv6_list = parse_ipv6_hints(ip_data, [])
+    %{ipv6_hints: ipv6_list}
+  end
+
+  defp parse_svc_param(key, value) do
+    # Generic parameter
+    %{key => value}
+  end
+
+  defp parse_alpn_list(<<>>, acc), do: Enum.reverse(acc)
+
+  defp parse_alpn_list(<<length::8, alpn::binary-size(length), rest::binary>>, acc) do
+    parse_alpn_list(rest, [alpn | acc])
+  end
+
+  defp parse_alpn_list(_, acc), do: Enum.reverse(acc)
+
+  defp parse_ipv4_hints(<<>>, acc), do: Enum.reverse(acc)
+
+  defp parse_ipv4_hints(<<a::8, b::8, c::8, d::8, rest::binary>>, acc) do
+    parse_ipv4_hints(rest, [{a, b, c, d} | acc])
+  end
+
+  defp parse_ipv4_hints(_, acc), do: Enum.reverse(acc)
+
+  defp parse_ipv6_hints(<<>>, acc), do: Enum.reverse(acc)
+
+  defp parse_ipv6_hints(
+         <<a1::16, a2::16, a3::16, a4::16, a5::16, a6::16, a7::16, a8::16, rest::binary>>,
+         acc
+       ) do
+    parse_ipv6_hints(rest, [{a1, a2, a3, a4, a5, a6, a7, a8} | acc])
+  end
+
+  defp parse_ipv6_hints(_, acc), do: Enum.reverse(acc)
+end


### PR DESCRIPTION
resolve #111

Moves the per-record-type rdata codec out of the 1262-line `dns_packet.ex` into a dedicated `DNSpacket.RData` module, the same approach used for the EDNS codec in #97. Behavior-preserving; the round-trip contract suite and the property tests (#107) are the safety net.

## Changes

- `lib/dns_packet/rdata.ex` (new, 619 lines): `encode/3` and `decode/4` clauses for every record type, plus their codec-only helpers — character-strings (TXT), NSEC type bitmap, SVCB/HTTPS service params, and the A/AAAA fast paths. Each type's encode and decode clauses are kept in the same order so they read side by side.
- `lib/dns_packet.ex` (1262 → 705 lines): keeps stable `@doc false` entry points as `defdelegate`s (`create_rdata/3`, `parse_rdata/4`, `create_type_bitmap/1`, `parse_type_bitmap/1`, `create_svc_params/1`, `parse_svc_params/1`) since tests call them directly.
- The shared name codec (`create_domain_name/1`, `create_character_string/1`, `parse_name/3`) **stays in DNSpacket** — it is also on the question/record framing hot path, where local calls keep their `@compile :inline` benefit. `parse_name/3` becomes `@doc false` public so RData can decode embedded names.

## Verification

- 229 tests pass (1 doctest, 4 properties, 224 tests); properties also green across seeds 1/42/9999
- `mix credo --strict` clean, `mix format` clean
- **Benchmark within ±5%** — median of 3 back-to-back A/B runs (main vs branch), to filter the heavy sub-µs noise on this machine:

  | scenario | Δ |
  |---|---|
  | parse simple query | +0.4% |
  | create simple query | −2.7% |
  | parse complex response | −0.1% |
  | parse EDNS response | +0.1% |
  | create EDNS response | +2.0% |
  | create complex response | +3.1% |

  (A single noisy run had shown large create-path swings in both directions; the median of paired runs confirms the extraction is performance-neutral, including the A/AAAA fast path.)