### PR TITLE
Document and typespec the per-record rdata contracts

### DIFF
--- a/lib/dns_packet.ex
+++ b/lib/dns_packet.ex
@@ -56,7 +56,8 @@ defmodule DNSpacket do
   - `type` - Record type (`:a`, `:ns`, `:cname`, etc.)
   - `class` - Record class (typically `:in`)
   - `ttl` - Time to live in seconds
-  - `rdata` - Record-specific data
+  - `rdata` - Record-specific data; the per-type map shape is documented in
+    `DNSpacket.RData` (see `t:DNSpacket.RData.rdata/0`)
 
   ### Question Format
 
@@ -87,19 +88,42 @@ defmodule DNSpacket do
   are accessible directly as top-level fields, while unknown options are
   preserved in a separate map.
 
-  ### Naming Convention
+  ### Base Fields
 
-  The structure follows industry-standard naming conventions:
+  Always present when `edns_info` is set:
 
-  - **Industry-standard abbreviations** for well-known options:
-    - `edns_client_subnet` → `ecs_family`, `ecs_subnet`, `ecs_source_prefix`, `ecs_scope_prefix`
-    - `nsid` → `nsid` (single field)
-    - `dau`, `dhu`, `n3u` → `dau_algorithms`, `dhu_algorithms`, `n3u_algorithms`
+  - `payload_size` - requestor's UDP payload size (16-bit)
+  - `ex_rcode` - upper 8 bits of the extended RCODE
+  - `version` - EDNS version (0)
+  - `dnssec` - DNSSEC OK (DO) bit (`0` or `1`)
+  - `z` - remaining 15 bits of the flags field
 
-  - **Full names** for complex or less common options:
-    - `extended_dns_error` → `extended_dns_error_info_code`, `extended_dns_error_extra_text`
-    - `edns_tcp_keepalive` → `edns_tcp_keepalive_timeout`, `edns_tcp_keepalive_raw_data`
-    - `cookie` → `cookie_client`, `cookie_server`
+  ### Option Fields
+
+  Each EDNS option flattens to one or more top-level keys. A key is only
+  present when its option appears in the packet; otherwise the field is
+  absent (not `nil`). The full set:
+
+  | Option | Flattened key(s) |
+  |--------|------------------|
+  | `edns_client_subnet` | `ecs_family`, `ecs_subnet`, `ecs_source_prefix`, `ecs_scope_prefix` |
+  | `cookie` | `cookie_client` (8 bytes), `cookie_server` (binary or `nil`) |
+  | `nsid` | `nsid` |
+  | `extended_dns_error` | `extended_dns_error_info_code`, `extended_dns_error_extra_text` |
+  | `edns_tcp_keepalive` | `edns_tcp_keepalive_timeout`, `edns_tcp_keepalive_raw_data` |
+  | `padding` | `padding_length` |
+  | `dau` / `dhu` / `n3u` | `dau_algorithms` / `dhu_algorithms` / `n3u_algorithms` (list of ints) |
+  | `edns_expire` | `edns_expire_expire` |
+  | `chain` | `chain_closest_encloser` |
+  | `edns_key_tag` | `edns_key_tag_key_tags` (list of ints) |
+  | `edns_client_tag` | `edns_client_tag_tag` |
+  | `edns_server_tag` | `edns_server_tag_tag` |
+  | `report_channel` | `report_channel_agent_domain` |
+  | `zoneversion` | `zoneversion_version` |
+  | `update_lease` | `update_lease_lease` |
+  | `llq` | `llq_version`, `llq_llq_opcode`, `llq_error_code`, `llq_llq_id`, `llq_lease_life` |
+  | `umbrella_ident` | `umbrella_ident_ident` |
+  | `deviceid` | `deviceid_device_id` |
 
   - **Unknown options** are stored in `unknown_options` as a map: `%{code => data}`
 

--- a/lib/dns_packet/rdata.ex
+++ b/lib/dns_packet/rdata.ex
@@ -20,10 +20,15 @@ defmodule DNSpacket.RData do
 
   Each record type's `rdata` is a map with the fields below. This is the
   shape `DNSpacket.parse/1` returns in every record's `:rdata`, and the
-  shape `DNSpacket.create/1` expects. Integer widths note the wire field
-  size; addresses are `:inet` address tuples (4-element for IPv4, 8-element
-  for IPv6) and domain names are dotted strings with the trailing root
-  label (`"example.com."`).
+  shape `DNSpacket.create/1` expects, with one asymmetry: NSEC
+  `type_bit_maps` is *returned* as a list of type atoms but `create/1`
+  *also* accepts a pre-built bitmap binary (see `t:nsec_rdata/0`).
+
+  Integer widths note the wire field size; addresses are `:inet` address
+  tuples (4-element for IPv4, 8-element for IPv6). Domain names are dotted
+  strings that must carry the trailing root label (`"example.com."`, not
+  `"example.com"`) — `create/1` encodes labels verbatim and a missing
+  trailing dot produces an unterminated name on the wire.
 
   | Type | Fields |
   |------|--------|
@@ -40,7 +45,7 @@ defmodule DNSpacket.RData do
   | `:naptr` | `order`, `preference` (16-bit), `flags`, `services`, `regexp`, `replacement` |
   | `:dnskey` | `flags` (16-bit), `protocol`, `algorithm` (8-bit), `public_key` |
   | `:ds` | `key_tag` (16-bit), `algorithm`, `digest_type` (8-bit), `digest` |
-  | `:rrsig` | `type_covered`, `key_tag` (16-bit), `algorithm`, `labels` (8-bit), `original_ttl`, `signature_expiration`, `signature_inception` (32-bit), `signer_name`, `signature` |
+  | `:rrsig` | `type_covered` (16-bit), `algorithm`, `labels` (8-bit), `original_ttl`, `signature_expiration`, `signature_inception` (32-bit), `key_tag` (16-bit), `signer_name`, `signature` |
   | `:nsec` | `next_domain_name`, `type_bit_maps` (list of type atoms) |
   | `:svcb` / `:https` | `priority` (16-bit), `target`, `svc_params` (see `t:svc_params/0`) |
 

--- a/lib/dns_packet/rdata.ex
+++ b/lib/dns_packet/rdata.ex
@@ -15,9 +15,175 @@ defmodule DNSpacket.RData do
 
   The round-trip contract is pinned by dns_packet_roundtrip_test.exs and
   the property suite (#107).
+
+  ## Record rdata shapes
+
+  Each record type's `rdata` is a map with the fields below. This is the
+  shape `DNSpacket.parse/1` returns in every record's `:rdata`, and the
+  shape `DNSpacket.create/1` expects. Integer widths note the wire field
+  size; addresses are `:inet` address tuples (4-element for IPv4, 8-element
+  for IPv6) and domain names are dotted strings with the trailing root
+  label (`"example.com."`).
+
+  | Type | Fields |
+  |------|--------|
+  | `:a` | `addr` (IPv4 tuple) |
+  | `:aaaa` | `addr` (IPv6 tuple) |
+  | `:ns` / `:cname` / `:ptr` | `name` |
+  | `:dname` | `target` |
+  | `:soa` | `mname`, `rname`, `serial`, `refresh`, `retry`, `expire`, `minimum` (all 32-bit) |
+  | `:mx` | `preference` (16-bit), `name` |
+  | `:txt` | `txt` (binary; ≥256 bytes is split into RFC 1035 character-strings on encode and rejoined on decode, see #95) |
+  | `:hinfo` | `cpu`, `os` (each ≤255-byte binary) |
+  | `:caa` | `flag` (8-bit), `tag`, `value` |
+  | `:srv` | `priority`, `weight`, `port` (16-bit), `target` |
+  | `:naptr` | `order`, `preference` (16-bit), `flags`, `services`, `regexp`, `replacement` |
+  | `:dnskey` | `flags` (16-bit), `protocol`, `algorithm` (8-bit), `public_key` |
+  | `:ds` | `key_tag` (16-bit), `algorithm`, `digest_type` (8-bit), `digest` |
+  | `:rrsig` | `type_covered`, `key_tag` (16-bit), `algorithm`, `labels` (8-bit), `original_ttl`, `signature_expiration`, `signature_inception` (32-bit), `signer_name`, `signature` |
+  | `:nsec` | `next_domain_name`, `type_bit_maps` (list of type atoms) |
+  | `:svcb` / `:https` | `priority` (16-bit), `target`, `svc_params` (see `t:svc_params/0`) |
+
+  Unknown record types decode to `%{type: type, class: class, rdata: binary}`
+  (the raw rdata) and encode by passing a raw binary straight through.
   """
 
   import Bitwise
+
+  @typedoc "IPv4 address record."
+  @type a_rdata :: %{addr: :inet.ip4_address()}
+
+  @typedoc "IPv6 address record."
+  @type aaaa_rdata :: %{addr: :inet.ip6_address()}
+
+  @typedoc "Single-name records: NS, CNAME, PTR."
+  @type name_rdata :: %{name: String.t()}
+
+  @typedoc "DNAME record (target rather than name)."
+  @type dname_rdata :: %{target: String.t()}
+
+  @typedoc "SOA record."
+  @type soa_rdata :: %{
+          mname: String.t(),
+          rname: String.t(),
+          serial: non_neg_integer(),
+          refresh: non_neg_integer(),
+          retry: non_neg_integer(),
+          expire: non_neg_integer(),
+          minimum: non_neg_integer()
+        }
+
+  @typedoc "MX record."
+  @type mx_rdata :: %{preference: non_neg_integer(), name: String.t()}
+
+  @typedoc """
+  TXT record. The value is the concatenation of one or more RFC 1035
+  character-strings; boundaries are not preserved (see #95).
+  """
+  @type txt_rdata :: %{txt: binary()}
+
+  @typedoc "HINFO record."
+  @type hinfo_rdata :: %{cpu: binary(), os: binary()}
+
+  @typedoc "CAA record."
+  @type caa_rdata :: %{flag: byte(), tag: binary(), value: binary()}
+
+  @typedoc "SRV record."
+  @type srv_rdata :: %{
+          priority: non_neg_integer(),
+          weight: non_neg_integer(),
+          port: non_neg_integer(),
+          target: String.t()
+        }
+
+  @typedoc "NAPTR record."
+  @type naptr_rdata :: %{
+          order: non_neg_integer(),
+          preference: non_neg_integer(),
+          flags: binary(),
+          services: binary(),
+          regexp: binary(),
+          replacement: String.t()
+        }
+
+  @typedoc "DNSKEY record."
+  @type dnskey_rdata :: %{
+          flags: non_neg_integer(),
+          protocol: byte(),
+          algorithm: byte(),
+          public_key: binary()
+        }
+
+  @typedoc "DS record."
+  @type ds_rdata :: %{
+          key_tag: non_neg_integer(),
+          algorithm: byte(),
+          digest_type: byte(),
+          digest: binary()
+        }
+
+  @typedoc "RRSIG record."
+  @type rrsig_rdata :: %{
+          type_covered: non_neg_integer(),
+          algorithm: byte(),
+          labels: byte(),
+          original_ttl: non_neg_integer(),
+          signature_expiration: non_neg_integer(),
+          signature_inception: non_neg_integer(),
+          key_tag: non_neg_integer(),
+          signer_name: String.t(),
+          signature: binary()
+        }
+
+  @typedoc """
+  NSEC record. On decode `type_bit_maps` is a list of type atoms (unknown
+  codes stay as integers); on encode a raw bitmap binary is also accepted.
+  """
+  @type nsec_rdata :: %{
+          next_domain_name: String.t(),
+          type_bit_maps: [atom() | non_neg_integer()] | binary()
+        }
+
+  @typedoc """
+  SVCB/HTTPS service parameters. Known keys are decoded to atoms; any other
+  key stays as its numeric SvcParamKey with the raw value binary.
+  """
+  @type svc_params :: %{
+          optional(:alpn) => [binary()],
+          optional(:port) => non_neg_integer(),
+          optional(:ipv4_hints) => [:inet.ip4_address()],
+          optional(:ipv6_hints) => [:inet.ip6_address()],
+          optional(non_neg_integer()) => binary()
+        }
+
+  @typedoc "SVCB / HTTPS record."
+  @type svcb_rdata :: %{priority: non_neg_integer(), target: String.t(), svc_params: svc_params()}
+
+  @typedoc """
+  Fallback shape for record types without a dedicated codec clause: the raw
+  rdata is kept verbatim alongside its type/class.
+  """
+  @type unknown_rdata :: %{type: atom(), class: atom(), rdata: binary()}
+
+  @typedoc "Any record's rdata, in the canonical parsed/created form."
+  @type rdata ::
+          a_rdata()
+          | aaaa_rdata()
+          | name_rdata()
+          | dname_rdata()
+          | soa_rdata()
+          | mx_rdata()
+          | txt_rdata()
+          | hinfo_rdata()
+          | caa_rdata()
+          | srv_rdata()
+          | naptr_rdata()
+          | dnskey_rdata()
+          | ds_rdata()
+          | rrsig_rdata()
+          | nsec_rdata()
+          | svcb_rdata()
+          | unknown_rdata()
 
   # Fast paths keep their inlining within this module
   @compile {:inline,


### PR DESCRIPTION
resolve #108

Formalizes the rdata map shapes that `parse/1` returns and `create/1` expects, as type specs and documentation. The hybrid EDNS flat structure stays as flat fields (the documented 35–69% access speedup is intentional), so this is **spec + documentation only — no struct or runtime change**.

## Changes

- **`DNSpacket.RData`**: `@type` for every record type's rdata (`a_rdata`, `aaaa_rdata`, `name_rdata`, `soa_rdata`, …), an `rdata/0` union, and a `svc_params/0` type — each with a `@typedoc`. Added a per-record rdata field table to the moduledoc.
- **`DNSpacket`**: the Record Format section now points to `t:DNSpacket.RData.rdata/0`; the partial EDNS naming-convention list is replaced with a complete flat-key reference (base fields + every option's flattened keys).

## Verification

- `mix dialyzer`: `Total errors: 0` (the new types are standalone aliases; no success-typing changes)
- 229 tests pass, `mix credo --strict` / `mix format` clean
- `mix docs` renders the new types on the `DNSpacket.RData` page and the EDNS key table on the `DNSpacket` page; introduced no new doc warnings (the `:inet` type references are written to avoid ExDoc autolinking)
- No `lib/` behavior change → benchmark unaffected