### PR TITLE
Bound compression-pointer following to prevent parse-time DoS

### DIFF
--- a/lib/dns_packet.ex
+++ b/lib/dns_packet.ex
@@ -170,7 +170,7 @@ defmodule DNSpacket do
               create_character_string: 1,
               add_rdlength: 1,
               parse_name: 3,
-              parse_name_acc: 3,
+              parse_name_acc: 4,
               parse_sections: 6,
               parse_question_fast: 4,
               parse_answer_fast: 4,
@@ -567,14 +567,12 @@ defmodule DNSpacket do
 
   ## Limitations
 
-  "Safe" here means it returns `{:error, _}` instead of raising on input it
-  cannot parse — it does **not** bound the work done. A maliciously crafted
-  compression-pointer loop (a name pointer that cycles) makes the underlying
-  `parse/1` recurse without terminating, exhausting CPU/memory; `parse_safe/1`
-  does not detect or interrupt that. For untrusted sources, also apply an
-  upstream limit (packet size cap and/or a per-parse timeout, e.g. parsing
-  inside a `Task` with `Task.yield/2` + `Task.shutdown/1`). Bounded pointer
-  following is tracked separately in #116.
+  "Safe" here means it returns `{:error, _}` instead of raising and does not
+  loop on malformed input. Name compression pointers are bounded to
+  strictly-decreasing offsets (#116), so a crafted pointer cycle is rejected
+  as `:malformed` rather than looping. The work is still proportional to the
+  packet size, so for untrusted sources a packet-size cap upstream remains
+  good practice.
   """
   @spec parse_safe(binary()) :: {:ok, t()} | {:error, parse_error()}
   def parse_safe(binary) when is_binary(binary) and byte_size(binary) < 12 do
@@ -707,29 +705,41 @@ defmodule DNSpacket do
   # names with it; local callers still get the @compile :inline benefit
   @doc false
   def parse_name(body, orig_body, "") do
-    parse_name_acc(body, orig_body, [])
+    parse_name_acc(body, orig_body, [], byte_size(orig_body))
   end
 
   def parse_name(body, orig_body, result) do
-    parse_name_acc(body, orig_body, [result])
+    parse_name_acc(body, orig_body, [result], byte_size(orig_body))
   end
 
-  defp parse_name_acc(<<0::8, body::binary>>, orig_body, []) do
+  # `ceiling` is the strictly-decreasing bound a compression pointer must
+  # stay under: a pointer may only point backward (RFC 1035 §4.1.4), so each
+  # followed pointer's offset must be < the offset we last jumped to. The
+  # jump targets therefore strictly decrease, making loops impossible. A
+  # pointer that violates this (offset >= ceiling) matches no clause and
+  # raises FunctionClauseError, which parse_safe/1 maps to :malformed (#116).
+  defp parse_name_acc(<<0::8, body::binary>>, orig_body, [], _ceiling) do
     {body, orig_body, "."}
   end
 
-  defp parse_name_acc(<<0::8, body::binary>>, orig_body, acc) do
+  defp parse_name_acc(<<0::8, body::binary>>, orig_body, acc, _ceiling) do
     {body, orig_body, IO.iodata_to_binary(Enum.reverse(acc))}
   end
 
-  defp parse_name_acc(<<0b11::2, offset::14, body::binary>>, orig_body, acc) do
+  defp parse_name_acc(<<0b11::2, offset::14, body::binary>>, orig_body, acc, ceiling)
+       when offset < ceiling do
     <<_::binary-size(^offset), tmp_body::binary>> = orig_body
-    {_, _, name} = parse_name_acc(tmp_body, orig_body, [])
+    {_, _, name} = parse_name_acc(tmp_body, orig_body, [], offset)
     {body, orig_body, IO.iodata_to_binary(Enum.reverse([name | acc]))}
   end
 
-  defp parse_name_acc(<<length::8, name::binary-size(length), body::binary>>, orig_body, acc) do
-    parse_name_acc(body, orig_body, ["." | [name | acc]])
+  defp parse_name_acc(
+         <<length::8, name::binary-size(length), body::binary>>,
+         orig_body,
+         acc,
+         ceiling
+       ) do
+    parse_name_acc(body, orig_body, ["." | [name | acc]], ceiling)
   end
 
   @doc false

--- a/test/dns_packet_parse_safe_test.exs
+++ b/test/dns_packet_parse_safe_test.exs
@@ -84,17 +84,18 @@ defmodule DNSpacketParseSafeTest do
   end
 
   describe "no-raise contract (fuzz)" do
-    # Bytes are kept in 0..63 so the generator never emits a compression
-    # pointer (a 0b11-prefixed byte is >= 0xC0). That keeps the fuzz
-    # hang-free — pointer-loop resistance is a separate, pre-existing
-    # concern shared with parse/1 and out of scope here. The point of this
-    # property is to confirm parse_safe's narrowed rescue is exhaustive:
-    # malformed input must always come back as a tagged tuple, never raise.
-    # If parse/1 raised an exception type the rescue does not cover, the
-    # case below would crash and surface it with the shrunk input.
+    # Full 0..255 bytes, so the generator freely produces compression
+    # pointers (0b11-prefixed bytes). Since #116 bounds pointer following to
+    # strictly-decreasing offsets, a pointer either resolves or raises
+    # FunctionClauseError — it can no longer loop, so the fuzz cannot hang.
+    # The point of this property is to confirm parse_safe's narrowed rescue
+    # is exhaustive: malformed input must always come back as a tagged
+    # tuple, never raise. If parse/1 raised an exception type the rescue
+    # does not cover, the case below would crash and surface it with the
+    # shrunk input.
     defp fuzz_binary do
       StreamData.map(
-        StreamData.list_of(StreamData.integer(0..63), max_length: 48),
+        StreamData.list_of(StreamData.integer(0..255), max_length: 48),
         &:erlang.list_to_binary/1
       )
     end

--- a/test/dns_packet_pointer_loop_test.exs
+++ b/test/dns_packet_pointer_loop_test.exs
@@ -55,5 +55,21 @@ defmodule DNSpacketPointerLoopTest do
       assert hd(parsed.answer).name == "a."
       assert hd(parsed.answer).rdata == %{addr: {192, 0, 2, 1}}
     end
+
+    test "a chained pointer (label then pointer, pointed-to by another pointer) decodes" do
+      # Exercises the strictly-decreasing chain the review asked about:
+      # answer2's name is a pointer to answer1's name (offset 21), whose
+      # own name is the label "z" followed by a pointer to the question
+      # name "x.y." at offset 12. Resolving answer2 jumps 21 -> 12, each
+      # strictly smaller, yielding "z.x.y." — a legitimate two-hop chain.
+      question = <<1, ?x, 1, ?y, 0, 0x00, 0x01, 0x00, 0x01>>
+      rr_tail = <<0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x3C, 0x00, 0x04, 192, 0, 2, 1>>
+      answer1 = <<1, ?z, 0xC0, 0x0C>> <> rr_tail
+      answer2 = <<0xC0, 0x15>> <> rr_tail
+      packet = header(1, 2) <> question <> answer1 <> answer2
+
+      assert {:ok, parsed} = DNSpacket.parse_safe(packet)
+      assert Enum.map(parsed.answer, & &1.name) == ["z.x.y.", "z.x.y."]
+    end
   end
 end

--- a/test/dns_packet_pointer_loop_test.exs
+++ b/test/dns_packet_pointer_loop_test.exs
@@ -1,0 +1,59 @@
+defmodule DNSpacketPointerLoopTest do
+  @moduledoc """
+  Compression-pointer loop protection (#116).
+
+  Name compression pointers must point strictly backward (RFC 1035
+  §4.1.4). A pointer that cycles (self-reference, a 2-cycle, or any
+  forward jump that re-enters) must be rejected rather than followed
+  forever: `parse/1` raises and `parse_safe/1` returns `{:error, :malformed}`.
+  Legitimate backward compression must still decode.
+
+  The loop cases carry a short `@tag timeout:` so that, before the fix,
+  the infinite loop fails as a timeout instead of hanging the suite.
+  """
+  use ExUnit.Case, async: true
+
+  # 12-byte header with QDCOUNT = 1; the question name starts at offset 12
+  defp header(qd \\ 1, an \\ 0) do
+    <<0x1234::16, 0::16, qd::16, an::16, 0::16, 0::16>>
+  end
+
+  describe "pointer loops are rejected, not followed" do
+    @tag timeout: 2_000
+    test "self-referential pointer (offset 12 -> 12)" do
+      packet = header() <> <<0xC0, 0x0C>>
+      assert DNSpacket.parse_safe(packet) == {:error, :malformed}
+      assert_raise FunctionClauseError, fn -> DNSpacket.parse(packet) end
+    end
+
+    @tag timeout: 2_000
+    test "two-pointer cycle (12 -> 14 -> 12)" do
+      # offset 12: pointer to 14; offset 14: pointer to 12
+      packet = header() <> <<0xC0, 0x0E, 0xC0, 0x0C>>
+      assert DNSpacket.parse_safe(packet) == {:error, :malformed}
+    end
+
+    @tag timeout: 2_000
+    test "forward pointer that re-enters (12 -> 14, 14 -> 14)" do
+      packet = header() <> <<0xC0, 0x0E, 0xC0, 0x0E>>
+      assert DNSpacket.parse_safe(packet) == {:error, :malformed}
+    end
+  end
+
+  describe "legitimate backward compression still decodes" do
+    test "an answer name pointing back to the question name resolves" do
+      # Question "a." at offset 12; answer name is a pointer to offset 12.
+      question = <<1, ?a, 0, 0x00, 0x01, 0x00, 0x01>>
+
+      answer =
+        <<0xC0, 0x0C, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x3C, 0x00, 0x04, 192, 0, 2, 1>>
+
+      packet = header(1, 1) <> question <> answer
+
+      assert {:ok, parsed} = DNSpacket.parse_safe(packet)
+      assert hd(parsed.question).qname == "a."
+      assert hd(parsed.answer).name == "a."
+      assert hd(parsed.answer).rdata == %{addr: {192, 0, 2, 1}}
+    end
+  end
+end

--- a/test/dns_packet_pointer_loop_test.exs
+++ b/test/dns_packet_pointer_loop_test.exs
@@ -38,6 +38,22 @@ defmodule DNSpacketPointerLoopTest do
       packet = header() <> <<0xC0, 0x0E, 0xC0, 0x0E>>
       assert DNSpacket.parse_safe(packet) == {:error, :malformed}
     end
+
+    test "a pointer to exactly the message end (offset == byte_size) is rejected" do
+      # packet is 14 bytes; the pointer at offset 12 targets offset 14.
+      # The guard is offset < ceiling, and ceiling only ever decreases from
+      # its initial byte_size(orig_body), so offset == byte_size can never
+      # pass — it is rejected before the inner slice could match an empty
+      # tmp_body.
+      packet = header() <> <<0xC0, 0x0E>>
+      assert byte_size(packet) == 14
+      assert DNSpacket.parse_safe(packet) == {:error, :malformed}
+    end
+
+    test "a pointer past the message end (offset > byte_size) is rejected" do
+      packet = header() <> <<0xC0, 0x64>>
+      assert DNSpacket.parse_safe(packet) == {:error, :malformed}
+    end
   end
 
   describe "legitimate backward compression still decodes" do

--- a/test/dns_packet_pointer_loop_test.exs
+++ b/test/dns_packet_pointer_loop_test.exs
@@ -39,6 +39,7 @@ defmodule DNSpacketPointerLoopTest do
       assert DNSpacket.parse_safe(packet) == {:error, :malformed}
     end
 
+    @tag timeout: 2_000
     test "a pointer to exactly the message end (offset == byte_size) is rejected" do
       # packet is 14 bytes; the pointer at offset 12 targets offset 14.
       # The guard is offset < ceiling, and ceiling only ever decreases from
@@ -50,6 +51,7 @@ defmodule DNSpacketPointerLoopTest do
       assert DNSpacket.parse_safe(packet) == {:error, :malformed}
     end
 
+    @tag timeout: 2_000
     test "a pointer past the message end (offset > byte_size) is rejected" do
       packet = header() <> <<0xC0, 0x64>>
       assert DNSpacket.parse_safe(packet) == {:error, :malformed}


### PR DESCRIPTION
resolve #116

Fixes the compression-pointer DoS surfaced in the #115 review: a crafted name pointer that cycles (self-reference, 2-cycle, forward re-entry) made `parse_name_acc/3` recurse forever, and `parse_safe/1` couldn't interrupt it (a loop isn't a raise).

## Fix

Enforce RFC 1035 §4.1.4 backward-only compression. A strictly-decreasing `ceiling` is threaded through the name parser (initially `byte_size(orig_body)`); a pointer is followed only when `offset < ceiling`, recursing with `ceiling = offset`. The jump-target sequence then strictly decreases, so **cycles are impossible**. A violating pointer matches no clause → `FunctionClauseError`, which `parse/1` raises (trusted-input contract) and `parse_safe/1` already maps to `{:error, :malformed}`.

Legitimate compression is unaffected: a name at offset `O` only references names at offsets `< O`, so well-formed backward pointers always satisfy the bound.

## Tests

- `test/dns_packet_pointer_loop_test.exs`: self-referential, 2-cycle, and forward-re-entry pointers → `parse_safe/1` returns `{:error, :malformed}` and `parse/1` raises. Each loop case carries `@tag timeout: 2_000` so the **pre-fix** infinite loop fails as a timeout instead of hanging the suite (verified: red before, green after).
- Pins that a legitimate answer-name-points-to-question-name packet still decodes.
- Widened the `parse_safe/1` no-raise fuzz to the full **0..255** byte range (previously `0..63` to dodge the loop) — it now exercises compression-pointer paths and stays hang-free and raise-free across seeds 0/1/42/9999/123456/777.
- Updated `parse_safe/1`'s "## Limitations": loops are now defended; only the size-proportional work note remains.

## Verification

- 246 tests pass (4 doctests, 6 properties, 236 tests), `mix dialyzer` 0 errors, credo/format clean
- **Benchmark (median of 5 back-to-back A/B runs)**: all scenarios within ±5% except "parse EDNS response", which sits at the noise floor — it read −5.1% at 3 runs and +5.1% at 5 runs (sign-flipping ⇒ noise, not a regression). The change is O(1) per name (one `byte_size/1` on a binary + an integer guard on the pointer path only):

  | scenario | Δ (median of 5) |
  |---|---|
  | parse simple query | +3.5% |
  | create simple query | +2.1% |
  | parse EDNS response | +5.1% (noise: −5.1% at 3 runs) |
  | parse complex response | 0.0% |
  | create EDNS response | +3.8% |
  | create complex response | +3.4% |