### PR TITLE
ci: allow manual workflow_dispatch trigger for Elixir CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -9,6 +9,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## 概要

Elixir CI ワークフローに `workflow_dispatch` トリガーを追加し、手動実行を可能にする。

## 目的

共有再利用ワークフロー（[smkwlab/.github#65](https://github.com/smkwlab/.github/pull/65) で OTP 29.0.2 / Elixir 1.20.1 に更新、`v1` タグ張り直し済み）の更新を、本リポジトリで **fresh run として実走確認**する。

再利用ワークフローの re-run は元コミット時点のタグ解決を再利用するため、タグ更新の検証には PR への push による fresh run が必要。本 PR の `pull_request` イベントで新 `v1`（OTP 29 / Elixir 1.20.1）が実際に解決・実行されることを確認する。あわせて `workflow_dispatch` 追加により今後の手動実走確認も容易になる。

## 検証

- `actionlint` green（exit 0）。
- 本 PR の Elixir CI run が OTP 29.0.2 / Elixir 1.20.1（latest matrix）で green になることを確認する。
