### PR TITLE
Cap decompressed name length at RFC 1035 255 octets (#119)

### DIFF
--- a/lib/dns_packet.ex
+++ b/lib/dns_packet.ex
@@ -742,9 +742,15 @@ defmodule DNSpacket do
     {body, orig_body, IO.iodata_to_binary(Enum.reverse([name | acc]))}
   end
 
-  # A label consumes 1 length octet + `length` bytes. Reject (by matching no
-  # clause -> FunctionClauseError -> :malformed) once the name would exceed the
-  # RFC 1035 255-octet limit; +1 leaves room for the terminating root octet.
+  # A label consumes its length octet + `length` data bytes, so `len + length
+  # + 1` is the running label-octet total once this label is included. RFC 1035
+  # §3.1 caps the whole wire name -- all label octets plus the terminating root
+  # octet -- at 255, so the label octets alone must stay <= 254 and the root
+  # supplies the final octet (that is where the 254 threshold, not 255, comes
+  # from -- the `+ 1` here is the label's own length octet, not the root). A
+  # label that would push the total past 254 matches no clause ->
+  # FunctionClauseError -> :malformed. Exactly-255-octet names are accepted;
+  # 256 is rejected (see the boundary test in dns_packet_name_length_test.exs).
   defp parse_name_acc(
          <<length::8, name::binary-size(length), body::binary>>,
          orig_body,

--- a/lib/dns_packet.ex
+++ b/lib/dns_packet.ex
@@ -164,6 +164,10 @@ defmodule DNSpacket do
   alias DNSpacket.EDNS
   alias DNSpacket.RData
 
+  # RFC 1035 §3.1: a domain name in wire form (all label + length octets plus
+  # the terminating root octet) is limited to 255 octets. See parse_name_acc/5.
+  @max_name_octets 255
+
   # Aggressive inlining for maximum speed (over memory efficiency)
   @compile {:inline,
             [
@@ -743,12 +747,12 @@ defmodule DNSpacket do
   end
 
   # A label consumes its length octet + `length` data bytes, so `len + length
-  # + 1` is the running label-octet total once this label is included. RFC 1035
-  # §3.1 caps the whole wire name -- all label octets plus the terminating root
-  # octet -- at 255, so the label octets alone must stay <= 254 and the root
-  # supplies the final octet (that is where the 254 threshold, not 255, comes
-  # from -- the `+ 1` here is the label's own length octet, not the root). A
-  # label that would push the total past 254 matches no clause ->
+  # + 1` is the running label-octet total once this label is included (the
+  # `+ 1` is the label's own length octet, not the root). RFC 1035 §3.1 caps
+  # the whole wire name -- all label octets plus the terminating root octet --
+  # at @max_name_octets, so the label octets alone must stay within
+  # @max_name_octets - 1 and the root supplies the final octet. A label that
+  # would push the total past that bound matches no clause ->
   # FunctionClauseError -> :malformed. Exactly-255-octet names are accepted;
   # 256 is rejected (see the boundary test in dns_packet_name_length_test.exs).
   defp parse_name_acc(
@@ -758,7 +762,7 @@ defmodule DNSpacket do
          ceiling,
          len
        )
-       when len + length + 1 <= 254 do
+       when len + length + 1 <= @max_name_octets - 1 do
     parse_name_acc(body, orig_body, ["." | [name | acc]], ceiling, len + length + 1)
   end
 

--- a/lib/dns_packet.ex
+++ b/lib/dns_packet.ex
@@ -170,7 +170,7 @@ defmodule DNSpacket do
               create_character_string: 1,
               add_rdlength: 1,
               parse_name: 3,
-              parse_name_acc: 4,
+              parse_name_acc: 5,
               parse_sections: 6,
               parse_question_fast: 4,
               parse_answer_fast: 4,
@@ -705,11 +705,11 @@ defmodule DNSpacket do
   # names with it; local callers still get the @compile :inline benefit
   @doc false
   def parse_name(body, orig_body, "") do
-    parse_name_acc(body, orig_body, [], byte_size(orig_body))
+    parse_name_acc(body, orig_body, [], byte_size(orig_body), 0)
   end
 
   def parse_name(body, orig_body, result) do
-    parse_name_acc(body, orig_body, [result], byte_size(orig_body))
+    parse_name_acc(body, orig_body, [result], byte_size(orig_body), 0)
   end
 
   # `ceiling` is the strictly-decreasing bound a compression pointer must
@@ -718,28 +718,42 @@ defmodule DNSpacket do
   # jump targets therefore strictly decrease, making loops impossible. A
   # pointer that violates this (offset >= ceiling) matches no clause and
   # raises FunctionClauseError, which parse_safe/1 maps to :malformed (#116).
-  defp parse_name_acc(<<0::8, body::binary>>, orig_body, [], _ceiling) do
+  #
+  # `len` is the running count of wire octets consumed by this name (each
+  # label's length byte + its bytes). RFC 1035 §3.1 caps a domain name at 255
+  # octets including the root; the label clause below refuses to accept a
+  # label that would push the name past that limit. `len` is threaded into the
+  # pointer recursion so the *assembled* name is bounded even across
+  # compression jumps. This closes the O(n²) decompression amplification: a
+  # pointer chain that appends a label at every hop can no longer grow the
+  # reassembled name without bound (see #119).
+  defp parse_name_acc(<<0::8, body::binary>>, orig_body, [], _ceiling, _len) do
     {body, orig_body, "."}
   end
 
-  defp parse_name_acc(<<0::8, body::binary>>, orig_body, acc, _ceiling) do
+  defp parse_name_acc(<<0::8, body::binary>>, orig_body, acc, _ceiling, _len) do
     {body, orig_body, IO.iodata_to_binary(Enum.reverse(acc))}
   end
 
-  defp parse_name_acc(<<0b11::2, offset::14, body::binary>>, orig_body, acc, ceiling)
+  defp parse_name_acc(<<0b11::2, offset::14, body::binary>>, orig_body, acc, ceiling, len)
        when offset < ceiling do
     <<_::binary-size(^offset), tmp_body::binary>> = orig_body
-    {_, _, name} = parse_name_acc(tmp_body, orig_body, [], offset)
+    {_, _, name} = parse_name_acc(tmp_body, orig_body, [], offset, len)
     {body, orig_body, IO.iodata_to_binary(Enum.reverse([name | acc]))}
   end
 
+  # A label consumes 1 length octet + `length` bytes. Reject (by matching no
+  # clause -> FunctionClauseError -> :malformed) once the name would exceed the
+  # RFC 1035 255-octet limit; +1 leaves room for the terminating root octet.
   defp parse_name_acc(
          <<length::8, name::binary-size(length), body::binary>>,
          orig_body,
          acc,
-         ceiling
-       ) do
-    parse_name_acc(body, orig_body, ["." | [name | acc]], ceiling)
+         ceiling,
+         len
+       )
+       when len + length + 1 <= 254 do
+    parse_name_acc(body, orig_body, ["." | [name | acc]], ceiling, len + length + 1)
   end
 
   @doc false

--- a/test/dns_packet_name_length_test.exs
+++ b/test/dns_packet_name_length_test.exs
@@ -1,0 +1,118 @@
+defmodule DNSpacketNameLengthTest do
+  @moduledoc """
+  RFC 1035 §3.1 total-name-length cap in name decompression (#119).
+
+  A domain name is limited to 255 wire octets. `parse_name_acc/5` refuses a
+  label that would push the assembled name past that limit, threading the
+  running octet count through the compression-pointer recursion so the bound
+  holds across pointer jumps. This closes the O(n²) decompression
+  amplification: a pointer chain that appends a label at every backward hop can
+  no longer grow the reassembled name without bound. Over-long names raise in
+  `parse/1` and become `{:error, :malformed}` in `parse_safe/1`, mirroring the
+  #116 pointer-loop rejection.
+
+  These tests build crafted binaries against `parse/1` / `parse_safe/1`, in the
+  same spirit as dns_packet_pointer_loop_test.exs.
+  """
+  use ExUnit.Case, async: true
+
+  # 12-byte header, QDCOUNT = 1; the question name starts at offset 12.
+  defp header, do: <<0x1234::16, 0x0100::16, 1::16, 0::16, 0::16, 0::16>>
+
+  # Build a message whose single QNAME is a depth-`depth` chain of backward
+  # compression pointers, each hop prepending a one-octet label ("a"). Every
+  # hop strictly decreases the offset, so #116 loop protection accepts it; only
+  # the length cap can reject it. node_i = <<1, ?a, ptr->node_{i-1}>>, node_0 =
+  # <<1, ?a, 0>>, QNAME = ptr->node_d.
+  defp deep_name_packet(depth) do
+    node_off = fn
+      0 -> 18
+      i -> 18 + 3 + 4 * (i - 1)
+    end
+
+    qname = <<0b11::2, node_off.(depth)::14>>
+    q_tail = <<1::16, 1::16>>
+
+    chain =
+      Enum.reduce(1..depth, <<1, ?a, 0>>, fn i, acc ->
+        acc <> <<1, ?a, 0b11::2, node_off.(i - 1)::14>>
+      end)
+
+    header() <> qname <> q_tail <> chain
+  end
+
+  describe "over-long names are rejected (RFC 1035 255-octet cap, #119)" do
+    test "a name longer than 255 wire octets is malformed, not accepted" do
+      # depth 200 => ~200 two-octet labels, far past the 255-octet limit.
+      packet = deep_name_packet(200)
+      assert DNSpacket.parse_safe(packet) == {:error, :malformed}
+      assert_raise FunctionClauseError, fn -> DNSpacket.parse(packet) end
+    end
+
+    @tag timeout: 2_000
+    test "the O(n^2) amplification packet is rejected quickly, not processed" do
+      # A depth-4000 chain would previously cost seconds of CPU; with the cap it
+      # is rejected after ~127 labels. The short timeout fails loudly if the
+      # quadratic work ever returns.
+      packet = deep_name_packet(4000)
+      assert DNSpacket.parse_safe(packet) == {:error, :malformed}
+    end
+
+    test "a single over-long label is capped too" do
+      # One 200-octet label already leaves <255 room for nothing else; two of
+      # them exceed the limit. Here: label(200) + label(200) + root.
+      big = <<200, String.duplicate("a", 200)::binary>>
+      packet = header() <> big <> big <> <<0>> <> <<1::16, 1::16>>
+      assert DNSpacket.parse_safe(packet) == {:error, :malformed}
+    end
+  end
+
+  describe "legitimate names still parse" do
+    test "a normal name round-trips through create |> parse" do
+      packet =
+        DNSpacket.create(%DNSpacket{
+          id: 1,
+          question: [%{qname: "www.example.com.", qtype: :a, qclass: :in}]
+        })
+
+      assert {:ok, parsed} = DNSpacket.parse_safe(packet)
+      assert hd(parsed.question).qname == "www.example.com."
+    end
+
+    test "a maximal-length name (<=255 wire octets) is accepted" do
+      # Three 63-octet labels (64 wire octets each = 192) + a short label, well
+      # within 255 including the root octet.
+      labels = [
+        String.duplicate("a", 63),
+        String.duplicate("b", 63),
+        String.duplicate("c", 63),
+        "dd"
+      ]
+
+      name = Enum.join(labels, ".") <> "."
+      wire_octets = Enum.reduce(labels, 1, fn l, acc -> acc + byte_size(l) + 1 end)
+      assert wire_octets <= 255
+
+      packet =
+        DNSpacket.create(%DNSpacket{id: 2, question: [%{qname: name, qtype: :a, qclass: :in}]})
+
+      assert {:ok, parsed} = DNSpacket.parse_safe(packet)
+      assert hd(parsed.question).qname == name
+    end
+
+    test "legitimate backward compression still decodes" do
+      # Two questions where the second name is a pointer to the first (the
+      # common compression case) must still parse.
+      hdr = <<0x1234::16, 0x0100::16, 2::16, 0::16, 0::16, 0::16>>
+      # q1: name <3,"www",7,"example",3,"com",0> at offset 12, then qtype/qclass
+      q1 = <<3, "www", 7, "example", 3, "com", 0>> <> <<1::16, 1::16>>
+      # q2: name is a pointer back to offset 12, then qtype/qclass
+      q2 = <<0b11::2, 12::14>> <> <<1::16, 1::16>>
+      packet = hdr <> q1 <> q2
+
+      assert {:ok, parsed} = DNSpacket.parse_safe(packet)
+      names = Enum.map(parsed.question, & &1.qname)
+      assert names == ["www.example.com.", "www.example.com."]
+    end
+  end
+end

--- a/test/dns_packet_name_length_test.exs
+++ b/test/dns_packet_name_length_test.exs
@@ -130,6 +130,36 @@ defmodule DNSpacketNameLengthTest do
       assert DNSpacket.parse_safe(packet_256) == {:error, :malformed}
     end
 
+    test "the 255-octet cap is enforced across a compression pointer" do
+      # Outer name = one 100-octet label (101 wire octets) then a pointer to a
+      # target. Because `len` is threaded into the pointer recursion, the
+      # target's labels are bounded by the *combined* running total, so a name
+      # assembled across a pointer jump is capped just like a flat name. This is
+      # the scenario "some labels, then jump to a long name": it must NOT slip
+      # past the limit.
+      #
+      # layout: header(12) | outer label(101) @12 | pointer @113 | qtype/qclass
+      #         | target @119
+      outer = <<100, String.duplicate("a", 100)::binary>>
+      target_off = 12 + byte_size(outer) + 2 + 4
+      ptr = <<0b11::2, target_off::14>>
+      q = header() <> outer <> ptr <> <<1::16, 1::16>>
+
+      # Combined = 101 (outer) + 153 (target label 152 + len octet) + 1 root =
+      # 255: accepted, and the pointer resolves to the full "a...b..." name.
+      target_ok = <<152, String.duplicate("b", 152)::binary, 0>>
+      assert {:ok, parsed} = DNSpacket.parse_safe(q <> target_ok)
+
+      assert hd(parsed.question).qname ==
+               String.duplicate("a", 100) <> "." <> String.duplicate("b", 152) <> "."
+
+      # One octet more in the target (label 153) makes the combined name 256:
+      # rejected, even though neither the outer name nor the target alone is
+      # over the limit.
+      target_over = <<153, String.duplicate("b", 153)::binary, 0>>
+      assert DNSpacket.parse_safe(q <> target_over) == {:error, :malformed}
+    end
+
     test "legitimate backward compression still decodes" do
       # Two questions where the second name is a pointer to the first (the
       # common compression case) must still parse.

--- a/test/dns_packet_name_length_test.exs
+++ b/test/dns_packet_name_length_test.exs
@@ -100,6 +100,36 @@ defmodule DNSpacketNameLengthTest do
       assert hd(parsed.question).qname == name
     end
 
+    test "a name of exactly 255 wire octets is accepted; 256 is rejected" do
+      # RFC 1035 §3.1 caps the wire name (label + length octets + root) at 255.
+      # Labels 63+63+63+61 => (64+64+64+62) = 254 label octets + 1 root = 255.
+      name_255 =
+        <<63, String.duplicate("a", 63)::binary, 63, String.duplicate("b", 63)::binary, 63,
+          String.duplicate("c", 63)::binary, 61, String.duplicate("d", 61)::binary, 0>>
+
+      assert byte_size(name_255) == 255
+      packet_255 = header() <> name_255 <> <<1::16, 1::16>>
+      assert {:ok, parsed} = DNSpacket.parse_safe(packet_255)
+
+      assert hd(parsed.question).qname ==
+               String.duplicate("a", 63) <>
+                 "." <>
+                 String.duplicate("b", 63) <>
+                 "." <>
+                 String.duplicate("c", 63) <>
+                 "." <>
+                 String.duplicate("d", 61) <> "."
+
+      # One octet over the limit (last label 62 => wire name 256) is rejected.
+      name_256 =
+        <<63, String.duplicate("a", 63)::binary, 63, String.duplicate("b", 63)::binary, 63,
+          String.duplicate("c", 63)::binary, 62, String.duplicate("d", 62)::binary, 0>>
+
+      assert byte_size(name_256) == 256
+      packet_256 = header() <> name_256 <> <<1::16, 1::16>>
+      assert DNSpacket.parse_safe(packet_256) == {:error, :malformed}
+    end
+
     test "legitimate backward compression still decodes" do
       # Two questions where the second name is a pointer to the first (the
       # common compression case) must still parse.


### PR DESCRIPTION
Fixes #119.

## Problem

`parse_name_acc` follows compression pointers with strictly-decreasing loop protection (#116) but enforced **no cap on the assembled name length**, and rebuilds the name with `IO.iodata_to_binary/1` at every pointer hop. A backward-pointer chain that appends a label at each hop therefore costs **O(depth²)** CPU/memory while the packet is only O(depth) bytes. `parse_safe/1` did not help — such a packet is not loop-malformed, so it returned `{:ok, _}` after doing the full quadratic work.

Measured (PoC, OTP 27 / Elixir 1.17): doubling chain depth ~4× the parse time; a single ≤64 KB message (one deep chain + ~4126 records pointing at it, ~10 ms/record) burns **~40 s of CPU**. Reachable over UDP: `tenbin_ex` / `tenbin_cache` don't cap packet size before parsing and read up to 65535 bytes, so an IP-fragmented ~64 KB datagram reaches the parser.

## Fix

Thread the running wire-octet count (`len`) through `parse_name_acc`, **including the pointer recursion**, and refuse a label that would push the name past the RFC 1035 §3.1 255-octet limit (`+1` reserves the root octet). Over-long names then raise in `parse/1` and become `{:error, :malformed}` in `parse_safe/1`, exactly like the #116 loop rejection.

## Verification

- New `test/dns_packet_name_length_test.exs`: over-long names / the O(n²) amplification packet / an over-long single label are rejected as `:malformed`; a normal name, a maximal ~255-octet name, and normal backward compression still decode.
- Full suite green (245 tests, 6 properties, 4 doctests), `mix credo --strict` clean, `mix compile --warnings-as-errors` clean.
- Post-fix PoC: malicious packets rejected in µs–low-ms (was ~40 s); pure-pointer worst case (depth 8000 × 300 records) parses in ~0.2 ms.

Found during an ecosystem security review (theme A-2). `parse_safe/1` separately verified to uphold its `{:ok,_} | {:error,reason}` contract on 200k random/mutated inputs (no raise, no hang).

🤖 Generated with [Claude Code](https://claude.com/claude-code)