### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Keep SHA-pinned third-party GitHub Actions up to date (Renovate here is
+  # mix-only, so it does not manage Actions). Reusable workflows stay on @v1.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       
     - name: Set up Elixir
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
       with:
         otp-version: '27.0'
         elixir-version: '1.18.3'
@@ -52,7 +52,7 @@ jobs:
         HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
         
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
       with:
         body: |
           ## Release ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

Supply-chain hardening (follow-up to smkwlab/.github#69, items 2/3/5): pin genuine third-party GitHub Actions in `.github/workflows/release.yml` to full 40-hex commit SHAs, with the human-readable tag preserved as a trailing comment.

| Action | Pinned SHA (tag) |
|---|---|
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` # v4.3.1 |
| `erlef/setup-beam` | `54075bcc5e249e4758d363f27d099f55d843f124` # v1.24.1 |
| `softprops/action-gh-release` | `de2c0eb89ae2a093876385947365aca7b0e5f844` # v1 |

## Notes

- Reusable `smkwlab/.github/.github/workflows/*.yml@v1` refs (in `elixir.yml`, `security.yml`, `ai-code-review.yml`) are **intentionally left on `@v1`** — that is the org's shared-CI channel.
- Added `.github/dependabot.yml` (github-actions ecosystem, weekly, grouped) because Renovate in this repo is **mix-only** and does not manage Actions. Dependabot keeps the SHA-pinned actions updated.

## Validation

- `actionlint -shellcheck= -pyflakes= .github/workflows/*.yml` → clean (exit 0)
- YAML parses for all workflow files and `dependabot.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
