### PR TITLE
TEST: validate reusable-workflow action bumps (cache v6 / codecov v7)

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -22,5 +22,5 @@ concurrency:
 
 jobs:
   ci:
-    uses: smkwlab/.github/.github/workflows/elixir-ci.yml@v1
+    uses: smkwlab/.github/.github/workflows/elixir-ci.yml@test-cache-codecov
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   security:
-    uses: smkwlab/.github/.github/workflows/security.yml@v1
+    uses: smkwlab/.github/.github/workflows/security.yml@test-cache-codecov
     secrets: inherit


### PR DESCRIPTION
**Do not merge.** Temporary test: points this repo's `elixir-ci`/`security` callers at `smkwlab/.github@test-cache-codecov` to exercise **cache v6 + codecov v7** (and the already-merged checkout v7 / github-script v9) in real consumer CI before smkwlab/.github#75 is merged and `v1` is moved. Will be closed after validation.