### PR TITLE
TEST: validate upload-artifact v7 (reusable elixir-ci)

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -22,5 +22,5 @@ concurrency:
 
 jobs:
   ci:
-    uses: smkwlab/.github/.github/workflows/elixir-ci.yml@v1
+    uses: smkwlab/.github/.github/workflows/elixir-ci.yml@test-upload-artifact
     secrets: inherit


### PR DESCRIPTION
**Do not merge.** Points elixir-ci caller at smkwlab/.github@test-upload-artifact to validate `upload-artifact v4→v7` (#85) in real consumer CI before merge + v1 move. Closed after validation.